### PR TITLE
0.0.77

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -814,4 +814,4 @@ export type { FilterType, FiltersValue, WidgetFilterProps };
 
 ---
 
-_Last updated: 2026-04-10 — library version 0.0.76_
+_Last updated: 2026-04-13 — library version 0.0.77_

--- a/ARCHITECTURE_RULES.md
+++ b/ARCHITECTURE_RULES.md
@@ -1,0 +1,26 @@
+# Architecture Rules For Agents (CLAUDE/CODEX)
+
+## Mandatory File Structure
+
+When creating or refactoring hooks/components, use this structure:
+
+```text
+FeatureName/
+├─ FeatureName.tsx|ts   # Only one component or one hook per file
+├─ constants.ts         # Constants only
+├─ utils.ts             # Reusable helper functions only
+├─ types.ts             # Type aliases and interfaces only
+└─ index.ts             # Public exports
+```
+
+## Rules
+
+- One hook per file (`useSomething.ts`).
+- One component per file (`Something.tsx`).
+- Do not declare reusable helpers/constants/types inside component or hook files.
+- Move helper functions to `utils.ts`.
+- Move constants to `constants.ts`.
+- Move interfaces/types to `types.ts`.
+- Keep files as siblings of the hook/component they support.
+- If a hook/component grows, create its own folder and expose public API via `index.ts`.
+- Preserve existing public imports by re-exporting from local `index.ts` files.

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Refactored `Dropdown` to use extracted `computeDropdownPosition(...)` utility logic instead of keeping positioning calculations inline.
 - Updated `DropdownPropsType` to extend `HTMLProps<HTMLDivElement>`, enabling passthrough container attributes (including `className` and other native `div` props).
-- Bumped package version to `0.0.77` in package metadata.
+- Aligned version references to `0.0.77` across package metadata and docs (`AGENTS.md`, `docs/README.md`, and this changelog).
 
 ## [0.0.76] - 2026-04-10
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.77] - 2026-04-13
+
+### Added
+
+- Added `ARCHITECTURE_RULES.md` with mandatory component/hook file-structure rules for agent-driven refactors.
+- Added `Dropdown` support files `constants.ts` and `utils.ts` to centralize viewport margins/offsets and positioning helpers.
+
+### Changed
+
+- Refactored `Dropdown` to use extracted `computeDropdownPosition(...)` utility logic instead of keeping positioning calculations inline.
+- Updated `DropdownPropsType` to extend `HTMLProps<HTMLDivElement>`, enabling passthrough container attributes (including `className` and other native `div` props).
+- Bumped package version to `0.0.77` in package metadata.
+
 ## [0.0.76] - 2026-04-10
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ This folder is meant to be copied into a project that consumes the library.
 Base compatibility:
 
 - `react` / `react-dom` `>=18.2 <20`
-- `@sito/dashboard` `0.0.76`
+- `@sito/dashboard` `0.0.77`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.76",
+      "version": "0.0.77",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.76",
+  "version": "0.0.77",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -6,38 +6,7 @@ import { createPortal } from "react-dom";
 
 // types
 import { DropdownPropsType } from "./types";
-
-const MARGIN = 8;
-
-function computePosition(
-  anchor: DOMRect,
-  dropdown: HTMLElement,
-): { top: number; left: number } {
-  const rect = dropdown.getBoundingClientRect();
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
-
-  let top = anchor.bottom + 4;
-  let left = anchor.left;
-
-  // Flip horizontally if overflows right edge
-  if (left + rect.width > vw - MARGIN) {
-    left = anchor.right - rect.width;
-  }
-
-  // Clamp to left edge
-  if (left < MARGIN) left = MARGIN;
-
-  // Flip vertically if not enough space below
-  if (top + rect.height > vh - MARGIN) {
-    top = anchor.top - rect.height - 4;
-  }
-
-  // Clamp to top edge
-  if (top < MARGIN) top = MARGIN;
-
-  return { top, left };
-}
+import { computeDropdownPosition } from "./utils";
 
 /**
  * Renders the Dropdown component.
@@ -45,7 +14,7 @@ function computePosition(
  * @returns Function result.
  */
 export const Dropdown = (props: DropdownPropsType) => {
-  const { children, open, onClose, anchorEl } = props;
+  const { children, open, onClose, anchorEl, className, ...rest } = props;
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -55,7 +24,7 @@ export const Dropdown = (props: DropdownPropsType) => {
     if (!open || !anchorEl || !el) return;
 
     const anchor = anchorEl.getBoundingClientRect();
-    const { top, left } = computePosition(anchor, el);
+    const { top, left } = computeDropdownPosition(anchor, el);
     el.style.top = `${top}px`;
     el.style.left = `${left}px`;
   }, [open, anchorEl]);
@@ -68,7 +37,7 @@ export const Dropdown = (props: DropdownPropsType) => {
 
     const onResize = () => {
       const anchor = anchorEl.getBoundingClientRect();
-      const { top, left } = computePosition(anchor, el);
+      const { top, left } = computeDropdownPosition(anchor, el);
       el.style.top = `${top}px`;
       el.style.left = `${left}px`;
     };
@@ -114,8 +83,9 @@ export const Dropdown = (props: DropdownPropsType) => {
       ref={containerRef}
       role="menu"
       tabIndex={-1}
-      className="dropdown-main opened"
+      className={`dropdown-main opened ${className ?? ""}`}
       onClick={(e) => e.stopPropagation()}
+      {...rest}
     >
       {children}
     </div>,

--- a/src/components/Dropdown/constants.ts
+++ b/src/components/Dropdown/constants.ts
@@ -1,0 +1,2 @@
+export const DROPDOWN_VIEWPORT_MARGIN = 8;
+export const DROPDOWN_ANCHOR_OFFSET = 4;

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -1,8 +1,12 @@
-import { ReactNode } from "react";
+import { HTMLProps } from "react";
 
-export type DropdownPropsType = {
-  children: ReactNode;
+export interface DropdownPropsType extends HTMLProps<HTMLDivElement> {
   open: boolean;
   onClose: () => void;
   anchorEl?: HTMLElement | null;
+}
+
+export type DropdownPositionType = {
+  top: number;
+  left: number;
 };

--- a/src/components/Dropdown/utils.ts
+++ b/src/components/Dropdown/utils.ts
@@ -1,0 +1,42 @@
+import { DROPDOWN_ANCHOR_OFFSET, DROPDOWN_VIEWPORT_MARGIN } from "./constants";
+import { DropdownPositionType } from "./types";
+
+/**
+ * Computes a viewport-safe position for a dropdown anchored to an element.
+ * @param anchor Bounding client rect of the anchor element.
+ * @param dropdown Dropdown element used to calculate rendered dimensions.
+ * @returns Top and left coordinates for fixed positioning.
+ */
+export function computeDropdownPosition(
+  anchor: DOMRect,
+  dropdown: HTMLElement,
+): DropdownPositionType {
+  const rect = dropdown.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let top = anchor.bottom + DROPDOWN_ANCHOR_OFFSET;
+  let left = anchor.left;
+
+  // Flip horizontally if overflows right edge.
+  if (left + rect.width > viewportWidth - DROPDOWN_VIEWPORT_MARGIN) {
+    left = anchor.right - rect.width;
+  }
+
+  // Clamp to left edge.
+  if (left < DROPDOWN_VIEWPORT_MARGIN) {
+    left = DROPDOWN_VIEWPORT_MARGIN;
+  }
+
+  // Flip vertically if not enough space below.
+  if (top + rect.height > viewportHeight - DROPDOWN_VIEWPORT_MARGIN) {
+    top = anchor.top - rect.height - DROPDOWN_ANCHOR_OFFSET;
+  }
+
+  // Clamp to top edge.
+  if (top < DROPDOWN_VIEWPORT_MARGIN) {
+    top = DROPDOWN_VIEWPORT_MARGIN;
+  }
+
+  return { top, left };
+}


### PR DESCRIPTION
## [0.0.77] - 2026-04-13

### Added

- Added `ARCHITECTURE_RULES.md` with mandatory component/hook file-structure rules for agent-driven refactors.
- Added `Dropdown` support files `constants.ts` and `utils.ts` to centralize viewport margins/offsets and positioning helpers.

### Changed

- Refactored `Dropdown` to use extracted `computeDropdownPosition(...)` utility logic instead of keeping positioning calculations inline.
- Updated `DropdownPropsType` to extend `HTMLProps<HTMLDivElement>`, enabling passthrough container attributes (including `className` and other native `div` props).
- Aligned version references to `0.0.77` across package metadata and docs (`AGENTS.md`, `docs/README.md`, and this changelog).