### PR TITLE
0.0.78

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.78] - 2026-04-13
+
+### Added
+
+- Added `AutocompleteInput` Storybook scenario `MultipleWithControllerRequired` to document required validation with `react-hook-form` `Controller` in `multiple` mode.
+- Added regression tests for `AutocompleteInput` required behavior in `multiple` mode and `TextInput` label required indicator rendering with `aria-required`.
+
+### Changed
+
+- Updated `AutocompleteInput` to resolve required state from both `required` and `aria-required` props and to expose the resulting `aria-required` value on the underlying input.
+- Updated `AutocompleteInput` native `required` handling in `multiple` mode so the input is required only while no options are selected.
+- Updated `AutocompleteInput` test assertion style to use `required` attribute checks compatible with current testing environment validation APIs.
+
+### Fixed
+
+- Fixed `TextInput` required asterisk rendering to also reflect `aria-required`, not only native `required`.
+
 ## [0.0.77] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.77",
+      "version": "0.0.78",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.77",
+  "version": "0.0.78",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.stories.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.stories.tsx
@@ -5,6 +5,7 @@ import type { Option } from "components";
 import { AutocompleteInput, Button } from "components";
 import { State } from "components";
 import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 
 const meta: Meta<typeof AutocompleteInput> = {
   title: "Components/Form/AutocompleteInput",
@@ -94,6 +95,57 @@ export const Multiple: Story = {
     return <Example />;
   },
   args: { state: State.default },
+};
+
+export const MultipleWithControllerRequired: Story = {
+  render: () => {
+    const Example = () => {
+      const { control, handleSubmit } = useForm<{
+        fruits: Option[] | null;
+      }>({
+        defaultValues: { fruits: null },
+      });
+
+      const onSubmit = (data: { fruits: Option[] | null }) => {
+        const values = data.fruits?.map((fruit) => fruit.name).join(", ");
+        alert(`Frutas seleccionadas: ${values}`);
+      };
+
+      return (
+        <form onSubmit={handleSubmit(onSubmit)} className="max-w-sm space-y-4">
+          <Controller
+            control={control}
+            name="fruits"
+            rules={{
+              validate: (value) =>
+                (Array.isArray(value) && value.length > 0) ||
+                "Selecciona al menos una fruta",
+            }}
+            render={({ field, fieldState }) => (
+              <AutocompleteInput
+                label="Frutas favoritas"
+                placeholder="Selecciona una o varias frutas"
+                multiple
+                required
+                options={options}
+                value={field.value}
+                onChange={(nextValue) =>
+                  field.onChange(Array.isArray(nextValue) ? nextValue : null)
+                }
+                helperText={fieldState.error?.message}
+                state={fieldState.error ? State.error : State.default}
+              />
+            )}
+          />
+          <Button type="submit" variant="submit">
+            Enviar
+          </Button>
+        </form>
+      );
+    };
+
+    return <Example />;
+  },
 };
 
 export const CustomLabel: Story = {

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
@@ -42,4 +42,33 @@ describe("AutocompleteInput", () => {
 
     expect(screen.getByTestId("value")).toHaveTextContent("Banana");
   });
+
+  it("disables native required once a value is selected in multiple mode", () => {
+    const Example = () => {
+      const [value, setValue] = useState<Option[] | null>(null);
+      return (
+        <AutocompleteInput
+          id="autocomplete-required-multiple"
+          label="Autocomplete"
+          multiple
+          required
+          value={value}
+          onChange={(nextValue) =>
+            setValue(Array.isArray(nextValue) ? nextValue : null)
+          }
+          options={options}
+        />
+      );
+    };
+
+    render(<Example />);
+
+    const input = screen.getByRole("textbox", { name: /autocomplete/i });
+    expect(input).toBeRequired();
+
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByText("Apple"));
+
+    expect(input).not.toBeRequired();
+  });
 });

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
@@ -64,11 +64,11 @@ describe("AutocompleteInput", () => {
     render(<Example />);
 
     const input = screen.getByRole("textbox", { name: /autocomplete/i });
-    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("required");
 
     fireEvent.focus(input);
     fireEvent.click(screen.getByText("Apple"));
 
-    expect(input).not.toBeRequired();
+    expect(input).not.toHaveAttribute("required");
   });
 });

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
@@ -43,8 +43,16 @@ export const AutocompleteInput = forwardRef(function (
     helperText = "",
     placeholder = "",
     multiple = false,
+    required = false,
+    "aria-required": ariaRequired = false,
     ...rest
   } = props;
+
+  const isAriaRequired =
+    ariaRequired === true || String(ariaRequired).toLowerCase() === "true";
+  const isRequired = Boolean(required || isAriaRequired);
+  const hasMultipleValue = multiple && Array.isArray(value) && value.length > 0;
+  const shouldRequireInput = isRequired && !hasMultipleValue;
 
   const [inputValue, setInputValue] = useState("");
 
@@ -234,6 +242,8 @@ export const AutocompleteInput = forwardRef(function (
             "autocomplete-text-input",
             inputContainerClassName,
           )}
+          required={shouldRequireInput}
+          aria-required={isRequired}
           ref={ref ?? localInputRef}
           {...rest}
         >

--- a/src/components/Form/TextInput/TextInput.test.tsx
+++ b/src/components/Form/TextInput/TextInput.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { State } from "../utils";
@@ -96,5 +96,11 @@ describe("TextInput", () => {
 
     expect(input).toBeTruthy();
     expect(input?.className).toContain("keep-label-up");
+  });
+
+  it("shows required indicator when aria-required is true", () => {
+    render(<TextInput id="email" label="Email" aria-required value="" />);
+
+    expect(screen.getByText("Email *")).toBeInTheDocument();
   });
 });

--- a/src/components/Form/TextInput/TextInput.tsx
+++ b/src/components/Form/TextInput/TextInput.tsx
@@ -60,6 +60,10 @@ export const TextInput = forwardRef(function (
   const hasValue = isControlled ? hasInputValue(value) : uncontrolledHasValue;
   const shouldKeepLabelUpByType = rest.type === "date";
   const keepLabelUp = Boolean(rest.placeholder) || shouldKeepLabelUpByType;
+  const isAriaRequired =
+    rest["aria-required"] === true ||
+    String(rest["aria-required"]).toLowerCase() === "true";
+  const isLabelRequired = Boolean(rest.required || isAriaRequired);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!isControlled) {
@@ -99,7 +103,7 @@ export const TextInput = forwardRef(function (
             )}
           >
             {label}
-            {rest.required ? " *" : ""}
+            {isLabelRequired ? " *" : ""}
           </label>
         )}
         {children}


### PR DESCRIPTION
## [0.0.78] - 2026-04-13

### Added

- Added `AutocompleteInput` Storybook scenario `MultipleWithControllerRequired` to document required validation with `react-hook-form` `Controller` in `multiple` mode.
- Added regression tests for `AutocompleteInput` required behavior in `multiple` mode and `TextInput` label required indicator rendering with `aria-required`.

### Changed

- Updated `AutocompleteInput` to resolve required state from both `required` and `aria-required` props and to expose the resulting `aria-required` value on the underlying input.
- Updated `AutocompleteInput` native `required` handling in `multiple` mode so the input is required only while no options are selected.
- Updated `AutocompleteInput` test assertion style to use `required` attribute checks compatible with current testing environment validation APIs.

### Fixed

- Fixed `TextInput` required asterisk rendering to also reflect `aria-required`, not only native `required`.