### PR TITLE
0.0.79

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed `TextInput` required asterisk rendering to also reflect `aria-required`, not only native `required`.
+- Fixed `TextInput` floating label overlap for native input types with browser-provided UI/text (`datetime-local`, `time`, `month`, `week`, `range`, `color`, and `file`) by keeping the label elevated by default, in addition to `date`.
+- Added regression test coverage for `TextInput` floating-label behavior across all supported native overlap-prone input types.
 
 ## [0.0.77] - 2026-04-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.78",
+      "version": "0.0.79",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.78",
+  "version": "0.0.79",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Form/TextInput/TextInput.stories.tsx
+++ b/src/components/Form/TextInput/TextInput.stories.tsx
@@ -122,6 +122,39 @@ export const Date: Story = {
   },
 };
 
+export const ControlledDate: Story = {
+  render: () => {
+    const ControlledDateExample = () => {
+      const { control, handleSubmit } = useForm<{ lastPaidAt: string }>({
+        defaultValues: { lastPaidAt: "" },
+      });
+
+      const onSubmit = (data: { lastPaidAt: string }) => {
+        alert(`Last Paid at: ${data.lastPaidAt}`);
+      };
+
+      return (
+        <form onSubmit={handleSubmit(onSubmit)} className="max-w-sm space-y-4">
+          <Controller
+            control={control}
+            name="lastPaidAt"
+            render={({ field: { value, ...rest } }) => (
+              <TextInput
+                type="range"
+                value={value ?? ""}
+                label="Last paid at"
+                autoComplete="Last paid at"
+                {...rest}
+              />
+            )}
+          />
+        </form>
+      );
+    };
+    return <ControlledDateExample />;
+  },
+};
+
 export const CustomLabel: Story = {
   args: {
     label: (

--- a/src/components/Form/TextInput/TextInput.test.tsx
+++ b/src/components/Form/TextInput/TextInput.test.tsx
@@ -88,15 +88,27 @@ describe("TextInput", () => {
     expect(input?.className).toContain("has-placeholder");
   });
 
-  it("keeps label up for date inputs to avoid native placeholder overlap", () => {
-    const { container } = render(
-      <TextInput label="Fecha" type="date" value={undefined} />,
-    );
-    const input = container.querySelector("input");
+  it.each([
+    "date",
+    "datetime-local",
+    "time",
+    "month",
+    "week",
+    "range",
+    "color",
+    "file",
+  ])(
+    "keeps label up for %s inputs to avoid native UI/placeholder overlap",
+    (type) => {
+      const { container } = render(
+        <TextInput label="Fecha" type={type} value={undefined} />,
+      );
+      const input = container.querySelector("input");
 
-    expect(input).toBeTruthy();
-    expect(input?.className).toContain("keep-label-up");
-  });
+      expect(input).toBeTruthy();
+      expect(input?.className).toContain("keep-label-up");
+    },
+  );
 
   it("shows required indicator when aria-required is true", () => {
     render(<TextInput id="email" label="Email" aria-required value="" />);

--- a/src/components/Form/TextInput/TextInput.tsx
+++ b/src/components/Form/TextInput/TextInput.tsx
@@ -26,6 +26,17 @@ const hasInputValue = (inputValue: TextInputPropsType["value"]) => {
   return `${inputValue}`.length > 0;
 };
 
+const ALWAYS_FLOATING_LABEL_INPUT_TYPES = new Set([
+  "date",
+  "datetime-local",
+  "time",
+  "month",
+  "week",
+  "range",
+  "color",
+  "file",
+]);
+
 /**
  * TextInput
  * @param {object} props
@@ -58,7 +69,9 @@ export const TextInput = forwardRef(function (
   );
 
   const hasValue = isControlled ? hasInputValue(value) : uncontrolledHasValue;
-  const shouldKeepLabelUpByType = rest.type === "date";
+  const shouldKeepLabelUpByType = ALWAYS_FLOATING_LABEL_INPUT_TYPES.has(
+    rest.type ?? "",
+  );
   const keepLabelUp = Boolean(rest.placeholder) || shouldKeepLabelUpByType;
   const isAriaRequired =
     rest["aria-required"] === true ||


### PR DESCRIPTION
### Fixed

- Fixed `TextInput` floating label overlap for native input types with browser-provided UI/text (`datetime-local`, `time`, `month`, `week`, `range`, `color`, and `file`) by keeping the label elevated by default, in addition to `date`.
- Added regression test coverage for `TextInput` floating-label behavior across all supported native overlap-prone input types.