### PR TITLE
0.0.80

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,6 +529,20 @@ import { FileInput } from "@sito/dashboard";
 />;
 ```
 
+For custom upload UIs where you only need the native file input, use `unstyled`:
+
+```tsx
+<FileInput
+  id="profile-photo-file-input"
+  unstyled
+  inputClassName="hidden"
+  accept="image/jpeg,image/png,image/webp"
+  onChange={(e) => setFile(e.currentTarget.files?.[0] ?? null)}
+/>
+```
+
+`hiddenContainer` is available as an alias of `unstyled`.
+
 ---
 
 ## 7. Button & IconButton
@@ -814,4 +828,4 @@ export type { FilterType, FiltersValue, WidgetFilterProps };
 
 ---
 
-_Last updated: 2026-04-13 — library version 0.0.77_
+_Last updated: 2026-04-15 — library version 0.0.80_

--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ export function UsersTable() {
 - `SelectInput` expects `Option` items with an `id` (plus optional `value`/`name`).
 - `CheckInput` is controlled with `checked` (not `value`).
 - `FileInput` `onChange` receives the native input event; read files from `e.currentTarget.files`.
+- `FileInput` supports `unstyled` (and alias `hiddenContainer`) to render only the native file input when you provide a custom upload UI.
+
+```tsx
+<FileInput
+  id="profile-photo-file-input"
+  unstyled
+  inputClassName="hidden"
+  accept="image/jpeg,image/png,image/webp"
+  onChange={(e) => onUpload(e.currentTarget.files?.[0] ?? null)}
+/>
+```
 
 ## `TableOptionsProvider` Initial State
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.80] - 2026-04-13
+
+### Added
+
+- Added `unstyled?: boolean` and `hiddenContainer?: boolean` (alias) to `FileInput` so consumers can render only the native `<input type="file" />` without the default dropzone container, label, and preview UI.
+- Added `FileInput` test coverage for `unstyled` and `hiddenContainer` modes to ensure input-only rendering works as expected.
+
+### Changed
+
+- Updated the `FileInput` Storybook `AsProfilePhoto` scenario to use `unstyled` mode for hidden-input profile photo flows.
+- Updated documentation to include `FileInput` input-only usage and the `hiddenContainer` alias.
+
 ## [0.0.79] - 2026-04-13
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ This folder is meant to be copied into a project that consumes the library.
 Base compatibility:
 
 - `react` / `react-dom` `>=18.2 <20`
-- `@sito/dashboard` `0.0.77`
+- `@sito/dashboard` `0.0.80`

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -376,6 +376,20 @@ const options: Option[] = [
 />;
 ```
 
+For custom upload UIs (for example profile photo pickers), render only the native input:
+
+```tsx
+<FileInput
+  id="profile-photo-file-input"
+  unstyled
+  inputClassName="hidden"
+  accept="image/jpeg,image/png,image/webp"
+  onChange={(e) => onUpload(e.currentTarget.files?.[0] ?? null)}
+/>
+```
+
+`hiddenContainer` is available as an alias of `unstyled`.
+
 `Option` shape expected by selection components:
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.79",
+      "version": "0.0.80",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.79",
+  "version": "0.0.80",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Form/FileInput/FileInput.stories.tsx
+++ b/src/components/Form/FileInput/FileInput.stories.tsx
@@ -1,8 +1,13 @@
-import { faCloudArrowUp } from "@fortawesome/free-solid-svg-icons";
+import {
+  faCamera,
+  faCloudArrowUp,
+  faSpinner,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import type { Meta, StoryObj } from "@storybook/react";
-import { FileInput } from "components";
-import { State } from "components";
+import { FileInput, IconButton, State } from "components";
+import { ChangeEvent, KeyboardEvent, useCallback, useState } from "react";
 
 const meta: Meta<typeof FileInput> = {
   title: "Components/Form/FileInput",
@@ -13,6 +18,8 @@ const meta: Meta<typeof FileInput> = {
     helperText: { control: "text" },
     accept: { control: "text" },
     multiple: { control: "boolean" },
+    unstyled: { control: "boolean" },
+    hiddenContainer: { control: "boolean" },
     disabled: { control: "boolean" },
     state: {
       control: "inline-radio",
@@ -53,5 +60,181 @@ export const MultipleFiles: Story = {
   args: {
     label: "Sube tus archivos",
     multiple: true,
+  },
+};
+
+type ProfileType = {
+  name: string;
+  photo: string | null;
+};
+
+type ProfilePhotoPropsType = {
+  profile: ProfileType;
+  isUploading: boolean;
+  onUpload: (file: File) => void;
+  onDelete: () => void;
+};
+
+function PhotoFallback() {
+  return (
+    <span
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: "1.5rem",
+        fontWeight: 700,
+        color: "#7a7a7a",
+      }}
+    >
+      SP
+    </span>
+  );
+}
+
+function ProfilePhoto({
+  profile,
+  isUploading,
+  onUpload,
+  onDelete,
+}: ProfilePhotoPropsType) {
+  const handleFileSelect = useCallback(() => {
+    const fileInput = document.getElementById("profile-photo-file-input");
+    if (fileInput instanceof HTMLInputElement) fileInput.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) {
+        onUpload(file);
+        e.target.value = "";
+      }
+    },
+    [onUpload],
+  );
+
+  const hasPhoto = !!profile.photo;
+  const handleContainerKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (!hasPhoto) return;
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleFileSelect();
+      }
+    },
+    [handleFileSelect, hasPhoto],
+  );
+
+  return (
+    <div className="flex flex-col items-start justify-start gap-3">
+      <div className="relative">
+        <div
+          className={`w-28 h-28 rounded-2xl overflow-hidden bg-base border-2 border-border flex items-center justify-center${hasPhoto ? " cursor-pointer" : ""}`}
+          onClick={hasPhoto ? handleFileSelect : undefined}
+          onKeyDown={handleContainerKeyDown}
+          role={hasPhoto ? "button" : undefined}
+          tabIndex={hasPhoto ? 0 : undefined}
+          title={hasPhoto ? "Subir nueva foto" : undefined}
+        >
+          {hasPhoto ? (
+            <img
+              src={profile.photo ?? ""}
+              className="w-full h-full object-cover"
+              alt={profile.name}
+            />
+          ) : (
+            <PhotoFallback />
+          )}
+          {isUploading && (
+            <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+              <FontAwesomeIcon
+                icon={faSpinner}
+                className="text-2xl text-white animate-spin"
+              />
+            </div>
+          )}
+        </div>
+
+        {!hasPhoto && (
+          <IconButton
+            icon={<FontAwesomeIcon icon={faCamera} />}
+            onClick={handleFileSelect}
+            disabled={isUploading}
+            color="primary"
+            className="top-1 right-1 absolute"
+            aria-label="Subir foto"
+          />
+        )}
+
+        {hasPhoto && (
+          <IconButton
+            icon={<FontAwesomeIcon icon={faTrash} />}
+            onClick={onDelete}
+            disabled={isUploading}
+            color="error"
+            className="top-1 right-1 absolute"
+            aria-label="Borrar foto"
+          />
+        )}
+      </div>
+
+      <FileInput
+        id="profile-photo-file-input"
+        unstyled
+        accept="image/jpeg,image/png,image/webp"
+        inputClassName="hidden"
+        disabled={isUploading}
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+}
+
+export const AsProfilePhoto: Story = {
+  render: () => {
+    const ProfilePhotoStory = () => {
+      const [profile, setProfile] = useState<ProfileType>({
+        name: "Sito User",
+        photo: null,
+      });
+      const [isUploading, setIsUploading] = useState(false);
+
+      const onUpload = useCallback((file: File) => {
+        setIsUploading(true);
+
+        const reader = new FileReader();
+        reader.onload = () => {
+          setTimeout(() => {
+            const result =
+              typeof reader.result === "string" ? reader.result : null;
+            setProfile((prev) => ({ ...prev, photo: result }));
+            setIsUploading(false);
+          }, 650);
+        };
+        reader.onerror = () => setIsUploading(false);
+
+        reader.readAsDataURL(file);
+      }, []);
+
+      const onDelete = useCallback(() => {
+        setProfile((prev) => ({ ...prev, photo: null }));
+      }, []);
+
+      return (
+        <div className="p-4">
+          <ProfilePhoto
+            profile={profile}
+            isUploading={isUploading}
+            onUpload={onUpload}
+            onDelete={onDelete}
+          />
+        </div>
+      );
+    };
+
+    return <ProfilePhotoStory />;
   },
 };

--- a/src/components/Form/FileInput/FileInput.test.tsx
+++ b/src/components/Form/FileInput/FileInput.test.tsx
@@ -44,4 +44,27 @@ describe("FileInput", () => {
     ).toBeTruthy();
     expect(screen.queryByText("two.txt")).toBeNull();
   });
+
+  it("renders only native input when unstyled is true", () => {
+    const { container } = render(
+      <FileInput unstyled aria-label="Archivo oculto" onChange={vi.fn()} />,
+    );
+
+    expect(container.querySelector(".file-input-container")).toBeNull();
+    expect(container.querySelector(".file-preview")).toBeNull();
+    expect(screen.getByLabelText("Archivo oculto")).toBeTruthy();
+  });
+
+  it("supports hiddenContainer as alias of unstyled", () => {
+    const { container } = render(
+      <FileInput
+        hiddenContainer
+        aria-label="Archivo oculto"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector(".file-input-container")).toBeNull();
+    expect(screen.getByLabelText("Archivo oculto")).toBeTruthy();
+  });
 });

--- a/src/components/Form/FileInput/FileInput.tsx
+++ b/src/components/Form/FileInput/FileInput.tsx
@@ -9,6 +9,7 @@ import {
   ChangeEvent,
   ForwardedRef,
   forwardRef,
+  MouseEvent,
   useCallback,
   useState,
 } from "react";
@@ -28,6 +29,8 @@ export const FileInput = forwardRef(function (
   const {
     children,
     label,
+    unstyled = false,
+    hiddenContainer = false,
     containerClassName = "",
     inputClassName = "",
     labelClassName = "",
@@ -39,12 +42,13 @@ export const FileInput = forwardRef(function (
     onClear,
     ...rest
   } = props;
+  const renderInputOnly = unstyled || hiddenContainer;
 
   const [files, setFiles] = useState<File[]>([]);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files) {
+      if (!renderInputOnly && e.target.files) {
         const selected = Array.from(e.target.files);
         setFiles((prev) =>
           multiple ? [...prev, ...selected] : selected.slice(0, 1),
@@ -52,7 +56,7 @@ export const FileInput = forwardRef(function (
       }
       onChange?.(e);
     },
-    [multiple, onChange],
+    [multiple, onChange, renderInputOnly],
   );
 
   const handleRemove = useCallback(
@@ -71,13 +75,24 @@ export const FileInput = forwardRef(function (
     onClear?.();
   }, [onClear]);
 
-  const handleInputClick = useCallback(
-    (e: React.MouseEvent<HTMLInputElement>) => {
-      // Ensure re-opening and re-selecting the same file triggers onChange
-      (e.currentTarget as HTMLInputElement).value = "";
-    },
-    [],
-  );
+  const handleInputClick = useCallback((e: MouseEvent<HTMLInputElement>) => {
+    // Ensure re-opening and re-selecting the same file triggers onChange
+    (e.currentTarget as HTMLInputElement).value = "";
+  }, []);
+
+  if (renderInputOnly) {
+    return (
+      <input
+        type="file"
+        ref={ref}
+        multiple={multiple}
+        onClick={handleInputClick}
+        onChange={handleChange}
+        className={classNames(inputClassName)}
+        {...rest}
+      />
+    );
+  }
 
   return (
     <div className={classNames("file-input-container", containerClassName)}>

--- a/src/components/Form/FileInput/types.ts
+++ b/src/components/Form/FileInput/types.ts
@@ -10,6 +10,14 @@ export interface FileInputPropsType
   iconClassName?: string;
   multiple?: boolean;
   children?: ReactNode;
-  label: string | ReactNode;
+  label?: string | ReactNode;
   onClear?: () => void;
+  /**
+   * Renders only the native input element without container, label and preview UI.
+   */
+  unstyled?: boolean;
+  /**
+   * Alias of `unstyled` kept for semantic clarity in hidden-input use cases.
+   */
+  hiddenContainer?: boolean;
 }


### PR DESCRIPTION
## [0.0.80] - 2026-04-13

### Added

- Added `unstyled?: boolean` and `hiddenContainer?: boolean` (alias) to `FileInput` so consumers can render only the native `<input type="file" />` without the default dropzone container, label, and preview UI.
- Added `FileInput` test coverage for `unstyled` and `hiddenContainer` modes to ensure input-only rendering works as expected.

### Changed

- Updated the `FileInput` Storybook `AsProfilePhoto` scenario to use `unstyled` mode for hidden-input profile photo flows.
- Updated documentation to include `FileInput` input-only usage and the `hiddenContainer` alias.