### PR TITLE
0.0.81

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,12 +615,13 @@ function MyMenu() {
 
 **Props:**
 
-| Prop       | Type                  | Required | Description                               |
-| ---------- | --------------------- | -------- | ----------------------------------------- |
-| `open`     | `boolean`             | Yes      | Controls visibility                       |
-| `onClose`  | `() => void`          | Yes      | Called on click-outside or Escape key     |
-| `anchorEl` | `HTMLElement \| null` | No       | Anchor element used for smart positioning |
-| `children` | `ReactNode`           | Yes      | Dropdown content                          |
+| Prop           | Type                  | Required | Description                                                       |
+| -------------- | --------------------- | -------- | ----------------------------------------------------------------- |
+| `open`         | `boolean`             | Yes      | Controls visibility                                               |
+| `onClose`      | `() => void`          | Yes      | Called on click-outside, Escape key, or click-inside (see below)  |
+| `anchorEl`     | `HTMLElement \| null` | No       | Anchor element used for smart positioning                         |
+| `closeOnClick` | `boolean`             | No       | Auto-close when clicking inside the dropdown. Defaults to `true`. |
+| `children`     | `ReactNode`           | Yes      | Dropdown content                                                  |
 
 Smart positioning: aligns below the anchor by default, flips up/left if it would overflow the viewport.
 Repositions automatically on window resize while open.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.81] - 2026-04-18
+
+### Added
+
+- Added `closeOnClick?: boolean` prop to `Dropdown` (defaults to `true`) that auto-closes the dropdown when clicking inside it.
+- Added `Dropdown` Storybook scenarios `CloseOnClick` and `KeepOpenOnClick` to document the new auto-close behavior and the opt-out via `closeOnClick={false}`.
+- Added `Dropdown` test coverage for default auto-close, explicit `closeOnClick={true}`, and persistent `closeOnClick={false}` behavior on both inner children and the menu container.
+
+### Changed
+
+- Updated `AGENTS.md` §9 Dropdown props table to document the new `closeOnClick` prop.
+
 ## [0.0.80] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.80",
+  "version": "0.0.81",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -146,6 +146,111 @@ export const EdgeDetection: Story = {
   },
 };
 
+export const CloseOnClick: Story = {
+  render: () => {
+    const Example = () => {
+      const [open, setOpen] = useState(false);
+      const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+      const [lastAction, setLastAction] = useState<string>("(none)");
+      return (
+        <div className="p-10">
+          <Button
+            variant="outlined"
+            onClick={(e) => {
+              setAnchorEl(e.currentTarget as HTMLElement);
+              setOpen((prev) => !prev);
+            }}
+          >
+            Toggle Dropdown (auto-close)
+          </Button>
+          <p className="mt-2 text-sm text-text-muted">
+            Last action: {lastAction}
+          </p>
+          <Dropdown
+            open={open}
+            onClose={() => setOpen(false)}
+            anchorEl={anchorEl}
+          >
+            <div className="flex flex-col gap-1 p-2 justify-start items-start">
+              <Button variant="text" onClick={() => setLastAction("Edit")}>
+                Edit
+              </Button>
+              <Button
+                variant="text"
+                onClick={() => setLastAction("View Details")}
+              >
+                View Details
+              </Button>
+              <Button
+                variant="text"
+                color="error"
+                onClick={() => setLastAction("Delete")}
+              >
+                Delete
+              </Button>
+            </div>
+          </Dropdown>
+        </div>
+      );
+    };
+    return <Example />;
+  },
+  args: {
+    open: false,
+    children: null,
+    onClose: () => {},
+    anchorEl: null,
+    closeOnClick: true,
+  },
+};
+
+export const KeepOpenOnClick: Story = {
+  render: () => {
+    const Example = () => {
+      const [open, setOpen] = useState(false);
+      const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+      const [count, setCount] = useState(0);
+      return (
+        <div className="p-10">
+          <Button
+            variant="outlined"
+            onClick={(e) => {
+              setAnchorEl(e.currentTarget as HTMLElement);
+              setOpen((prev) => !prev);
+            }}
+          >
+            Toggle Dropdown (persistent)
+          </Button>
+          <Dropdown
+            open={open}
+            onClose={() => setOpen(false)}
+            anchorEl={anchorEl}
+            closeOnClick={false}
+          >
+            <div className="flex flex-col gap-1 p-2 justify-start items-start min-w-48">
+              <p className="text-sm text-text-muted">Clicks: {count}</p>
+              <Button variant="text" onClick={() => setCount((c) => c + 1)}>
+                Increment
+              </Button>
+              <Button variant="text" onClick={() => setOpen(false)}>
+                Close manually
+              </Button>
+            </div>
+          </Dropdown>
+        </div>
+      );
+    };
+    return <Example />;
+  },
+  args: {
+    open: false,
+    children: null,
+    onClose: () => {},
+    anchorEl: null,
+    closeOnClick: false,
+  },
+};
+
 export const AboveRelativeLayers: Story = {
   render: () => {
     const Example = () => {

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -5,9 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Dropdown } from "./Dropdown";
 
-const renderDropdown = (open: boolean, onClose = vi.fn()) => {
+const renderDropdown = (
+  open: boolean,
+  onClose = vi.fn(),
+  closeOnClick?: boolean,
+) => {
   render(
-    <Dropdown open={open} onClose={onClose}>
+    <Dropdown open={open} onClose={onClose} closeOnClick={closeOnClick}>
       <button type="button">Inside</button>
     </Dropdown>,
   );
@@ -61,6 +65,36 @@ describe("Dropdown", () => {
   it("does not call onClose on Escape when closed", () => {
     const { onClose } = renderDropdown(false);
     fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking inside by default (closeOnClick=true)", () => {
+    const { onClose } = renderDropdown(true);
+    fireEvent.click(screen.getByRole("button", { name: "Inside" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on click inside when closeOnClick is explicitly true", () => {
+    const { onClose } = renderDropdown(true, vi.fn(), true);
+    fireEvent.click(screen.getByRole("button", { name: "Inside" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose on click inside when closeOnClick is false", () => {
+    const { onClose } = renderDropdown(true, vi.fn(), false);
+    fireEvent.click(screen.getByRole("button", { name: "Inside" }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose on click on dropdown container itself when closeOnClick=true", () => {
+    const { onClose } = renderDropdown(true);
+    fireEvent.click(screen.getByRole("menu"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose on click on dropdown container when closeOnClick=false", () => {
+    const { onClose } = renderDropdown(true, vi.fn(), false);
+    fireEvent.click(screen.getByRole("menu"));
     expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -14,7 +14,15 @@ import { computeDropdownPosition } from "./utils";
  * @returns Function result.
  */
 export const Dropdown = (props: DropdownPropsType) => {
-  const { children, open, onClose, anchorEl, className, ...rest } = props;
+  const {
+    children,
+    open,
+    onClose,
+    anchorEl,
+    className,
+    closeOnClick = true,
+    ...rest
+  } = props;
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -84,7 +92,10 @@ export const Dropdown = (props: DropdownPropsType) => {
       role="menu"
       tabIndex={-1}
       className={`dropdown-main opened ${className ?? ""}`}
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (closeOnClick) onClose();
+      }}
       {...rest}
     >
       {children}

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -4,6 +4,7 @@ export interface DropdownPropsType extends HTMLProps<HTMLDivElement> {
   open: boolean;
   onClose: () => void;
   anchorEl?: HTMLElement | null;
+  closeOnClick?: boolean;
 }
 
 export type DropdownPositionType = {


### PR DESCRIPTION
## [0.0.81] - 2026-04-18

### Added

- Added `closeOnClick?: boolean` prop to `Dropdown` (defaults to `true`) that auto-closes the dropdown when clicking inside it.
- Added `Dropdown` Storybook scenarios `CloseOnClick` and `KeepOpenOnClick` to document the new auto-close behavior and the opt-out via `closeOnClick={false}`.
- Added `Dropdown` test coverage for default auto-close, explicit `closeOnClick={true}`, and persistent `closeOnClick={false}` behavior on both inner children and the menu container.

### Changed

- Updated `AGENTS.md` §9 Dropdown props table to document the new `closeOnClick` prop.