### PR TITLE
0.0.82

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [0.0.82] - 2026-04-18
 
+### Added
+
+- Added `stopPropagation?: boolean` prop to `Action` (defaults to `false`) that calls `event.stopPropagation()` on click, preventing the click event from bubbling to parent handlers.
+- Added `Action` Storybook file (`Action.stories.tsx`) with scenarios `Basic`, `WithText`, `Disabled`, `WithoutTooltip`, `StopPropagation`, and `WithoutStopPropagation` to document the new prop.
+
+### Changed
+
+- Updated `Action` JSDoc and consumer `usage-guide.md` to document the new `stopPropagation` prop.
+
 ## [0.0.81] - 2026-04-18
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.82] - 2026-04-18
+
 ## [0.0.81] - 2026-04-18
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ This folder is meant to be copied into a project that consumes the library.
 Base compatibility:
 
 - `react` / `react-dom` `>=18.2 <20`
-- `@sito/dashboard` `0.0.80`
+- `@sito/dashboard` `0.0.81`

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -438,6 +438,17 @@ import { useRef, useState } from "react";
   onClick={() => console.log("view")}
 />;
 
+{
+  /* Prevent click from bubbling to parent handlers (e.g. row onClick) */
+}
+<Action
+  id="edit"
+  tooltip="Edit"
+  icon={<span>E</span>}
+  onClick={() => console.log("edit")}
+  stopPropagation
+/>;
+
 <Actions
   actions={[
     { id: "edit", tooltip: "Edit", icon: <span>E</span>, onClick: () => {} },

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -474,6 +474,7 @@ function ExampleDropdown() {
         open={open}
         onClose={() => setOpen(false)}
         anchorEl={triggerRef.current}
+        closeOnClick
       >
         <ul>
           <li>Item 1</li>

--- a/src/components/Actions/Action.stories.tsx
+++ b/src/components/Actions/Action.stories.tsx
@@ -1,0 +1,78 @@
+import { faEye } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Action } from "./Action";
+
+const meta = {
+  title: "Components/Actions/Action",
+  component: Action,
+  tags: ["autodocs"],
+  args: {
+    id: "view",
+    tooltip: "View",
+    icon: <FontAwesomeIcon icon={faEye} />,
+    onClick: () => alert("View"),
+  },
+} satisfies Meta<typeof Action>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const WithText: Story = {
+  args: { showText: true },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const WithoutTooltip: Story = {
+  args: { showTooltips: false },
+};
+
+export const StopPropagation: Story = {
+  args: {
+    stopPropagation: true,
+    tooltip: "Click me (parent click suppressed)",
+    onClick: () => alert("Action clicked — parent onClick NOT fired"),
+  },
+  render: (args) => (
+    <div
+      onClick={() => alert("Parent clicked")}
+      style={{
+        padding: 24,
+        border: "1px dashed #888",
+        cursor: "pointer",
+        display: "inline-block",
+      }}
+    >
+      <span style={{ marginRight: 12 }}>Parent container</span>
+      <Action {...args} />
+    </div>
+  ),
+};
+
+export const WithoutStopPropagation: Story = {
+  args: {
+    stopPropagation: false,
+    tooltip: "Click me (parent click fires too)",
+    onClick: () => alert("Action clicked"),
+  },
+  render: (args) => (
+    <div
+      onClick={() => alert("Parent clicked")}
+      style={{
+        padding: 24,
+        border: "1px dashed #888",
+        cursor: "pointer",
+        display: "inline-block",
+      }}
+    >
+      <span style={{ marginRight: 12 }}>Parent container</span>
+      <Action {...args} />
+    </div>
+  ),
+};

--- a/src/components/Actions/Action.tsx
+++ b/src/components/Actions/Action.tsx
@@ -33,6 +33,7 @@ export function Action<TEntity extends BaseDto>(
     showText = false,
     showTooltips = true,
     className = "",
+    stopPropagation = false,
   } = props;
 
   return !hidden ? (
@@ -47,7 +48,7 @@ export function Action<TEntity extends BaseDto>(
       disabled={disabled}
       aria-label={tooltip}
       onClick={(e) => {
-        e.stopPropagation();
+        if (stopPropagation) e.stopPropagation();
         onClick?.();
       }}
       aria-disabled={disabled}

--- a/src/components/Actions/Action.tsx
+++ b/src/components/Actions/Action.tsx
@@ -17,6 +17,7 @@ import { ActionPropsType } from "./types";
  * @param props.showText - When `true`, `tooltip` is rendered as visible text next to the icon. Defaults to `false`.
  * @param props.showTooltips - When `false`, the tooltip is suppressed. Defaults to `true`.
  * @param props.className - Additional CSS class applied to the button.
+ * @param props.stopPropagation - When `true`, `event.stopPropagation()` is called on click, preventing the event from bubbling to parent handlers. Defaults to `false`.
  * @returns The action button element, or `null` when `hidden` is `true`.
  */
 export function Action<TEntity extends BaseDto>(

--- a/src/components/Actions/types.ts
+++ b/src/components/Actions/types.ts
@@ -18,4 +18,5 @@ export interface ActionPropsType<
   showText?: boolean;
   showTooltips?: boolean;
   className?: string;
+  stopPropagation?: boolean;
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -93,8 +93,8 @@ export const Dropdown = (props: DropdownPropsType) => {
       tabIndex={-1}
       className={`dropdown-main opened ${className ?? ""}`}
       onClick={(e) => {
-        e.stopPropagation();
         if (closeOnClick) onClose();
+        e.stopPropagation();
       }}
       {...rest}
     >


### PR DESCRIPTION
## [0.0.82] - 2026-04-18

### Added

- Added `stopPropagation?: boolean` prop to `Action` (defaults to `false`) that calls `event.stopPropagation()` on click, preventing the click event from bubbling to parent handlers.
- Added `Action` Storybook file (`Action.stories.tsx`) with scenarios `Basic`, `WithText`, `Disabled`, `WithoutTooltip`, `StopPropagation`, and `WithoutStopPropagation` to document the new prop.

### Changed

- Updated `Action` JSDoc and consumer `usage-guide.md` to document the new `stopPropagation` prop.