### PR TITLE
0.0.83

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -501,8 +501,11 @@ import { AutocompleteInput } from "@sito/dashboard";
   onChange={setCountry}
   options={countryOptions}
   placeholder="Search…"
+  autoSelectOnBlur
 />;
 ```
+
+`autoSelectOnBlur` defaults to `true`. In single-select mode, when the input loses focus and the typed text exactly matches an option label, that option is selected automatically. Matching is case-insensitive and trims surrounding spaces.
 
 ### 6.4 `CheckInput`
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ export function UsersTable() {
 ## Form Input Notes
 
 - `SelectInput` expects `Option` items with an `id` (plus optional `value`/`name`).
+- `AutocompleteInput` supports `autoSelectOnBlur` (`true` by default). In single-select mode, blur selects the matching option when the typed text exactly matches an option label, ignoring case and surrounding spaces.
 - `CheckInput` is controlled with `checked` (not `value`).
 - `FileInput` `onChange` receives the native input event; read files from `e.currentTarget.files`.
 - `FileInput` supports `unstyled` (and alias `hiddenContainer`) to render only the native file input when you provide a custom upload UI.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.83] - 2026-06-05
+
+### Added
+
+- Added `autoSelectOnBlur?: boolean` prop to `AutocompleteInput` (defaults to `true`) so single-select inputs automatically select an option on blur when the typed text exactly matches an available option label.
+- Added `AutocompleteInput` Storybook scenarios `AutoSelectOnBlur` and `AutoSelectOnBlurDisabled` to document the default blur auto-selection behavior and the opt-out via `autoSelectOnBlur={false}`.
+- Added regression test coverage for `AutocompleteInput` blur auto-selection behavior with both the default enabled state and the explicit disabled state.
+
+### Changed
+
+- Updated consumer documentation (`README.md`, `docs/usage-guide.md`, and `AGENTS.md`) to document `AutocompleteInput.autoSelectOnBlur` and its default behavior.
+
 ## [0.0.82] - 2026-04-18
 
 ### Added

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -361,6 +361,7 @@ const options: Option[] = [
     { id: "us", name: "USA" },
   ]}
   label="Country"
+  autoSelectOnBlur
 />;
 
 <CheckInput
@@ -375,6 +376,8 @@ const options: Option[] = [
   onChange={(e) => console.log(e.target.files)}
 />;
 ```
+
+`autoSelectOnBlur` defaults to `true`. In single-select mode, blur selects the matching option when the typed text exactly matches an option label, ignoring case and surrounding spaces.
 
 For custom upload UIs (for example profile photo pickers), render only the native input:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.81",
+      "version": "0.0.82",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.81",
+  "version": "0.0.83",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.stories.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.stories.tsx
@@ -148,6 +148,78 @@ export const MultipleWithControllerRequired: Story = {
   },
 };
 
+export const AutoSelectOnBlur: Story = {
+  render: (args) => {
+    const Example = () => {
+      const [value, setValue] = useState<Option | Option[] | null>(null);
+
+      return (
+        <div className="max-w-sm">
+          <AutocompleteInput
+            {...args}
+            label="Fruta"
+            placeholder="Escribe una fruta exacta y sal del input"
+            options={options}
+            value={value}
+            onChange={setValue}
+          />
+          <p className="mt-2 text-sm text-gray-500">
+            Escribe por ejemplo "Mango" o "mango" y haz blur para seleccionar
+            automáticamente la opción.
+          </p>
+          {!Array.isArray(value) && (
+            <p className="mt-2 text-sm text-gray-500">
+              Valor: {value ? String(value.name ?? value.value) : "(vacío)"}
+            </p>
+          )}
+        </div>
+      );
+    };
+
+    return <Example />;
+  },
+  args: {
+    state: State.default,
+    autoSelectOnBlur: true,
+  },
+};
+
+export const AutoSelectOnBlurDisabled: Story = {
+  render: (args) => {
+    const Example = () => {
+      const [value, setValue] = useState<Option | Option[] | null>(null);
+
+      return (
+        <div className="max-w-sm">
+          <AutocompleteInput
+            {...args}
+            label="Fruta"
+            placeholder="Escribe una fruta exacta y sal del input"
+            options={options}
+            value={value}
+            onChange={setValue}
+          />
+          <p className="mt-2 text-sm text-gray-500">
+            Aunque escribas una coincidencia exacta, al hacer blur no se
+            selecciona automáticamente.
+          </p>
+          {!Array.isArray(value) && (
+            <p className="mt-2 text-sm text-gray-500">
+              Valor: {value ? String(value.name ?? value.value) : "(vacío)"}
+            </p>
+          )}
+        </div>
+      );
+    };
+
+    return <Example />;
+  },
+  args: {
+    state: State.default,
+    autoSelectOnBlur: false,
+  },
+};
+
 export const CustomLabel: Story = {
   render: (args) => {
     const Example = () => {

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
@@ -71,4 +71,61 @@ describe("AutocompleteInput", () => {
 
     expect(input).not.toHaveAttribute("required");
   });
+
+  it("selects the matching option on blur by default", () => {
+    const Example = () => {
+      const [value, setValue] = useState<Option | Option[] | null>(null);
+      return (
+        <>
+          <AutocompleteInput
+            id="autocomplete-blur"
+            label="Autocomplete blur"
+            value={value}
+            onChange={setValue}
+            options={options}
+          />
+          {!Array.isArray(value) && (
+            <p data-testid="value">{value?.name ?? ""}</p>
+          )}
+        </>
+      );
+    };
+
+    render(<Example />);
+
+    const input = screen.getByLabelText("Autocomplete blur");
+    fireEvent.change(input, { target: { value: "banana" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByTestId("value")).toHaveTextContent("Banana");
+  });
+
+  it("does not select on blur when autoSelectOnBlur is false", () => {
+    const Example = () => {
+      const [value, setValue] = useState<Option | Option[] | null>(null);
+      return (
+        <>
+          <AutocompleteInput
+            id="autocomplete-blur-disabled"
+            label="Autocomplete blur disabled"
+            value={value}
+            onChange={setValue}
+            options={options}
+            autoSelectOnBlur={false}
+          />
+          {!Array.isArray(value) && (
+            <p data-testid="value">{value?.name ?? ""}</p>
+          )}
+        </>
+      );
+    };
+
+    render(<Example />);
+
+    const input = screen.getByLabelText("Autocomplete blur disabled");
+    fireEvent.change(input, { target: { value: "banana" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByTestId("value")).toHaveTextContent("");
+  });
 });

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
@@ -7,6 +7,7 @@ import { Chip, Close, IconButton, Option, TextInput } from "components";
 import { classNames } from "lib";
 import {
   ChangeEvent,
+  FocusEvent as ReactFocusEvent,
   ForwardedRef,
   forwardRef,
   KeyboardEvent as ReactKeyboardEvent,
@@ -43,8 +44,11 @@ export const AutocompleteInput = forwardRef(function (
     helperText = "",
     placeholder = "",
     multiple = false,
+    autoSelectOnBlur = true,
     required = false,
     "aria-required": ariaRequired = false,
+    onBlur,
+    onFocus,
     ...rest
   } = props;
 
@@ -68,26 +72,33 @@ export const AutocompleteInput = forwardRef(function (
   const [highlightedSuggestionIndex, setHighlightedSuggestionIndex] =
     useState(-1);
 
-  const suggestions = useMemo(
+  const getOptionLabel = useCallback(
+    (option: Option) => String(option.value ?? option.name ?? ""),
+    [],
+  );
+
+  const availableOptions = useMemo(
     () =>
       options.filter((option) => {
-        const isIncluded = String(option.value ?? option.name)
-          .toLowerCase()
-          .includes(inputValue?.toLowerCase());
-
         if (Array.isArray(value) && value.length) {
-          return (
-            isIncluded && !value.some((selected) => selected.id === option.id)
-          );
+          return !value.some((selected) => selected.id === option.id);
         }
 
         if (value && !Array.isArray(value)) {
-          return isIncluded && value.id !== option.id;
+          return value.id !== option.id;
         }
 
-        return isIncluded;
+        return true;
       }),
-    [options, value, inputValue],
+    [options, value],
+  );
+
+  const suggestions = useMemo(
+    () =>
+      availableOptions.filter((option) =>
+        getOptionLabel(option).toLowerCase().includes(inputValue.toLowerCase()),
+      ),
+    [availableOptions, getOptionLabel, inputValue],
   );
 
   useEffect(() => {
@@ -148,6 +159,62 @@ export const AutocompleteInput = forwardRef(function (
       setShowSuggestions(false);
     },
     [multiple, onChange, value],
+  );
+
+  const findSuggestionMatchingInput = useCallback(
+    (searchValue: string) => {
+      const normalizedSearchValue = searchValue.trim().toLowerCase();
+
+      if (!normalizedSearchValue) return null;
+
+      return (
+        availableOptions.find(
+          (option) =>
+            getOptionLabel(option).trim().toLowerCase() ===
+            normalizedSearchValue,
+        ) ?? null
+      );
+    },
+    [availableOptions, getOptionLabel],
+  );
+
+  const handleFocus = useCallback(
+    (event: ReactFocusEvent<HTMLInputElement>) => {
+      setShowSuggestions(true);
+      onFocus?.(event);
+    },
+    [onFocus],
+  );
+
+  const handleBlur = useCallback(
+    (event: ReactFocusEvent<HTMLInputElement>) => {
+      onBlur?.(event);
+
+      if (
+        autocompleteRef.current &&
+        event.relatedTarget instanceof Node &&
+        autocompleteRef.current.contains(event.relatedTarget)
+      ) {
+        return;
+      }
+
+      const matchedSuggestion = autoSelectOnBlur
+        ? findSuggestionMatchingInput(event.currentTarget.value)
+        : null;
+
+      if (matchedSuggestion) {
+        handleSuggestionClick(matchedSuggestion);
+        return;
+      }
+
+      setShowSuggestions(false);
+    },
+    [
+      autoSelectOnBlur,
+      findSuggestionMatchingInput,
+      handleSuggestionClick,
+      onBlur,
+    ],
   );
 
   const handleKeyDown = useCallback(
@@ -235,7 +302,8 @@ export const AutocompleteInput = forwardRef(function (
           onChange={handleChange}
           placeholder={placeholder}
           helperText={helperText}
-          onFocus={() => setShowSuggestions(true)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           label={label}
           containerClassName={classNames(
@@ -320,6 +388,7 @@ export const AutocompleteInput = forwardRef(function (
                   suggestions.findIndex((item) => item.id === suggestion.id),
                 )
               }
+              onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {
                 handleSuggestionClick(suggestion);
                 e.stopPropagation();

--- a/src/components/Form/AutocompleteInput/types.ts
+++ b/src/components/Form/AutocompleteInput/types.ts
@@ -8,6 +8,7 @@ export interface AutocompleteInputPropsType extends Omit<
   value: Option | Option[] | null;
   onChange: (value: Option | Option[] | null) => void;
   multiple?: boolean;
+  autoSelectOnBlur?: boolean;
   inputContainerClassName?: string;
   options: Option[];
 }


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.0.83] - 2026-06-05

### Added

- Added `autoSelectOnBlur?: boolean` prop to `AutocompleteInput` (defaults to `true`) so single-select inputs automatically select an option on blur when the typed text exactly matches an available option label.
- Added `AutocompleteInput` Storybook scenarios `AutoSelectOnBlur` and `AutoSelectOnBlurDisabled` to document the default blur auto-selection behavior and the opt-out via `autoSelectOnBlur={false}`.
- Added regression test coverage for `AutocompleteInput` blur auto-selection behavior with both the default enabled state and the explicit disabled state.

### Changed

- Updated consumer documentation (`README.md`, `docs/usage-guide.md`, and `AGENTS.md`) to document `AutocompleteInput.autoSelectOnBlur` and its default behavior.
