### PR TITLE
0.0.85

### DIFF
--- a/docs/style-customization.md
+++ b/docs/style-customization.md
@@ -88,7 +88,7 @@ The library defines these base tokens:
 | ------------------- | ------------------------------------------------------------------------------------------------ |
 | `Table`             | `className`, `contentClassName`, `columns[].className`                                           |
 | `Actions`           | `className`, `itemClassName`, `actionClassName`                                                  |
-| `Action`            | `className`                                                                                      |
+| `Action`            | `className`, `iconClassName`, `labelClassName`                                                   |
 | `ActionsDropdown`   | `className`                                                                                      |
 | `Button`            | `className`                                                                                      |
 | `IconButton`        | `className`, `iconClassName`                                                                     |
@@ -157,6 +157,8 @@ If you need high granularity, you can override internal library classes.
 - `.tooltip-text`
 - `.actions-container`
 - `.action`
+- `.action-icon`
+- `.action-label`
 - `.icon-action`
 - `.text-action`
 

--- a/docs/translations-reference.md
+++ b/docs/translations-reference.md
@@ -36,9 +36,9 @@ If a component that calls `useTranslation()` is rendered without the provider, i
 
 ### Required when non-sticky actions are used (ellipsis dropdown)
 
-| Key                                  | Where used        | Purpose                                           |
-| ------------------------------------ | ----------------- | ------------------------------------------------- |
-| `_accessibility:buttons.openActions` | `ActionsDropdown` | Aria label/name/tooltip for actions menu trigger. |
+| Key                                  | Where used        | Purpose                                       |
+| ------------------------------------ | ----------------- | --------------------------------------------- |
+| `_accessibility:buttons.openActions` | `ActionsDropdown` | Aria label/name for the actions menu trigger. |
 
 ### Required when column visibility or reset is used (`canHideColumns` / `canReset`)
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -151,6 +151,13 @@ import { useRef, useState } from "react";
   ]}
 />;
 
+<Actions
+  showTooltips={false}
+  actions={[
+    { id: "edit", tooltip: "Edit", icon: <span>E</span>, onClick: () => {} },
+  ]}
+/>;
+
 <ActionsDropdown
   actions={[
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sito/dashboard",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sito/dashboard",
-      "version": "0.0.83",
+      "version": "0.0.84",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.0.83",
+  "version": "0.0.84",
   "type": "module",
   "description": "UI library with custom components for dashboards",
   "main": "dist/index.cjs",

--- a/src/components/Actions/Action.stories.tsx
+++ b/src/components/Actions/Action.stories.tsx
@@ -29,6 +29,15 @@ export const Disabled: Story = {
   args: { disabled: true },
 };
 
+export const StyledParts: Story = {
+  args: {
+    showText: true,
+    className: "border border-red-500",
+    iconClassName: "text-red-500",
+    labelClassName: "uppercase tracking-wide",
+  },
+};
+
 export const StopPropagation: Story = {
   args: {
     stopPropagation: true,

--- a/src/components/Actions/Action.stories.tsx
+++ b/src/components/Actions/Action.stories.tsx
@@ -29,10 +29,6 @@ export const Disabled: Story = {
   args: { disabled: true },
 };
 
-export const WithoutTooltip: Story = {
-  args: { showTooltips: false },
-};
-
 export const StopPropagation: Story = {
   args: {
     stopPropagation: true,

--- a/src/components/Actions/Action.tsx
+++ b/src/components/Actions/Action.tsx
@@ -16,6 +16,8 @@ import { ActionPropsType } from "./types";
  * @param props.disabled - When `true`, the button is disabled. Defaults to `false`.
  * @param props.showText - When `true`, `tooltip` is rendered as visible text next to the icon. Defaults to `false`.
  * @param props.className - Additional CSS class applied to the button.
+ * @param props.iconClassName - Additional CSS class applied to the icon wrapper.
+ * @param props.labelClassName - Additional CSS class applied to the visible label wrapper.
  * @param props.stopPropagation - When `true`, `event.stopPropagation()` is called on click, preventing the event from bubbling to parent handlers. Defaults to `false`.
  * @returns The action button element, or `null` when `hidden` is `true`.
  */
@@ -32,6 +34,8 @@ export function Action<TEntity extends BaseDto>(
     disabled = false,
     showText = false,
     className = "",
+    iconClassName = "",
+    labelClassName = "",
     stopPropagation = false,
     "aria-describedby": ariaDescribedBy,
   } = props;
@@ -54,7 +58,12 @@ export function Action<TEntity extends BaseDto>(
       }}
       aria-disabled={disabled}
     >
-      {icon} {showText && tooltip}
+      <span className={classNames("action-icon", iconClassName)}>{icon}</span>
+      {showText && (
+        <span className={classNames("action-label", labelClassName)}>
+          {tooltip}
+        </span>
+      )}
       {children}
     </button>
   ) : null;

--- a/src/components/Actions/Action.tsx
+++ b/src/components/Actions/Action.tsx
@@ -15,7 +15,6 @@ import { ActionPropsType } from "./types";
  * @param props.hidden - When `true`, the button is not rendered. Defaults to `false`.
  * @param props.disabled - When `true`, the button is disabled. Defaults to `false`.
  * @param props.showText - When `true`, `tooltip` is rendered as visible text next to the icon. Defaults to `false`.
- * @param props.showTooltips - When `false`, the tooltip is suppressed. Defaults to `true`.
  * @param props.className - Additional CSS class applied to the button.
  * @param props.stopPropagation - When `true`, `event.stopPropagation()` is called on click, preventing the event from bubbling to parent handlers. Defaults to `false`.
  * @returns The action button element, or `null` when `hidden` is `true`.
@@ -32,9 +31,9 @@ export function Action<TEntity extends BaseDto>(
     hidden = false,
     disabled = false,
     showText = false,
-    showTooltips = true,
     className = "",
     stopPropagation = false,
+    "aria-describedby": ariaDescribedBy,
   } = props;
 
   return !hidden ? (
@@ -48,13 +47,12 @@ export function Action<TEntity extends BaseDto>(
       )}
       disabled={disabled}
       aria-label={tooltip}
+      aria-describedby={ariaDescribedBy}
       onClick={(e) => {
         if (stopPropagation) e.stopPropagation();
         onClick?.();
       }}
       aria-disabled={disabled}
-      data-tooltip-id="tooltip"
-      data-tooltip-content={showTooltips ? tooltip : ""}
     >
       {icon} {showText && tooltip}
       {children}

--- a/src/components/Actions/Actions.stories.tsx
+++ b/src/components/Actions/Actions.stories.tsx
@@ -41,3 +41,7 @@ export const Basic: Story = {};
 export const WithText: Story = {
   args: { showActionTexts: true },
 };
+
+export const WithoutTooltips: Story = {
+  args: { showTooltips: false },
+};

--- a/src/components/Actions/Actions.test.tsx
+++ b/src/components/Actions/Actions.test.tsx
@@ -87,4 +87,31 @@ describe("Actions", () => {
     fireEvent.mouseEnter(screen.getByRole("button", { name: "Delete record" }));
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
+
+  it("supports per-action button, icon, and label classes", () => {
+    render(
+      <Actions
+        showActionTexts
+        actionClassName="global-action"
+        actions={[
+          makeAction({
+            tooltip: "Styled action",
+            className: "per-action",
+            iconClassName: "per-icon",
+            labelClassName: "per-label",
+          }),
+        ]}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Styled action" });
+    expect(button.classList.contains("global-action")).toBe(true);
+    expect(button.classList.contains("per-action")).toBe(true);
+    expect(
+      button.querySelector(".action-icon")?.classList.contains("per-icon"),
+    ).toBe(true);
+    expect(
+      button.querySelector(".action-label")?.classList.contains("per-label"),
+    ).toBe(true);
+  });
 });

--- a/src/components/Actions/Actions.test.tsx
+++ b/src/components/Actions/Actions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { Actions } from "./Actions";
@@ -69,5 +69,22 @@ describe("Actions", () => {
     expect(
       screen.getByRole("button", { name: "Delete record" }),
     ).toBeInTheDocument();
+  });
+
+  it("shows a tooltip for icon-only actions by default", () => {
+    render(<Actions actions={[makeAction({ tooltip: "Delete record" })]} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "Delete record" }));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Delete record");
+  });
+
+  it("does not render tooltips when showTooltips is false", () => {
+    render(
+      <Actions
+        actions={[makeAction({ tooltip: "Delete record" })]}
+        showTooltips={false}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "Delete record" }));
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -1,10 +1,11 @@
 // styles
 import "./styles.css";
 
+// components
+import { Tooltip } from "components";
 // lib
 import { BaseDto, classNames } from "lib";
 
-// components
 import { Action } from "./Action";
 // types
 import { ActionsContainerPropsType } from "./types";
@@ -16,7 +17,7 @@ import { ActionsContainerPropsType } from "./types";
  * @param props.className - Additional CSS class applied to the `<ul>` container.
  * @param props.itemClassName - Additional CSS class applied to each `<li>` item.
  * @param props.actionClassName - Additional CSS class applied to each `Action` button.
- * @param props.showTooltips - Whether to show tooltips on each action. Defaults to `true`.
+ * @param props.showTooltips - Whether to wrap icon-only actions with a `Tooltip`. Defaults to `true`.
  * @param props.showActionTexts - Whether to render the action label as visible text. Defaults to `false`.
  * @returns A `<ul>` element containing one `<li>` per action.
  */
@@ -38,12 +39,21 @@ export function Actions<TRow extends BaseDto>(
           key={action.id}
           className={classNames("actions-container-item", itemClassName)}
         >
-          <Action
-            showTooltips={showTooltips}
-            showText={showActionTexts}
-            className={actionClassName}
-            {...action}
-          />
+          {showTooltips && !showActionTexts && !action.hidden ? (
+            <Tooltip content={action.tooltip}>
+              <Action
+                showText={showActionTexts}
+                className={actionClassName}
+                {...action}
+              />
+            </Tooltip>
+          ) : (
+            <Action
+              showText={showActionTexts}
+              className={actionClassName}
+              {...action}
+            />
+          )}
         </li>
       ))}
     </ul>

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -34,28 +34,36 @@ export function Actions<TRow extends BaseDto>(
   } = props;
   return (
     <ul className={classNames("actions-container", className)}>
-      {actions.map((action) => (
-        <li
-          key={action.id}
-          className={classNames("actions-container-item", itemClassName)}
-        >
-          {showTooltips && !showActionTexts && !action.hidden ? (
-            <Tooltip content={action.tooltip}>
+      {actions.map((action) => {
+        const { className: perActionClassName, ...actionProps } = action;
+        const mergedActionClassName = classNames(
+          actionClassName,
+          perActionClassName,
+        );
+
+        return (
+          <li
+            key={action.id}
+            className={classNames("actions-container-item", itemClassName)}
+          >
+            {showTooltips && !showActionTexts && !action.hidden ? (
+              <Tooltip content={action.tooltip}>
+                <Action
+                  showText={showActionTexts}
+                  className={mergedActionClassName}
+                  {...actionProps}
+                />
+              </Tooltip>
+            ) : (
               <Action
                 showText={showActionTexts}
-                className={actionClassName}
-                {...action}
+                className={mergedActionClassName}
+                {...actionProps}
               />
-            </Tooltip>
-          ) : (
-            <Action
-              showText={showActionTexts}
-              className={actionClassName}
-              {...action}
-            />
-          )}
-        </li>
-      ))}
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/components/Actions/ActionsDropdown.tsx
+++ b/src/components/Actions/ActionsDropdown.tsx
@@ -45,8 +45,6 @@ export const ActionsDropdown = <TRow extends BaseDto>(
         className="actions-dropdown-trigger"
         aria-label={t("_accessibility:buttons.openActions")}
         name={t("_accessibility:buttons.openActions")}
-        data-tooltip-id="tooltip"
-        data-tooltip-content={t("_accessibility:buttons.openActions")}
       />
       <Dropdown
         open={openMenu}

--- a/src/components/Actions/styles.css
+++ b/src/components/Actions/styles.css
@@ -16,6 +16,14 @@
   @apply bg-base hover:bg-base-light text-text flex items-center justify-center gap-2 transition;
 }
 
+.action-icon {
+  @apply inline-flex items-center justify-center;
+}
+
+.action-label {
+  @apply inline-flex items-center;
+}
+
 .icon-action {
   @apply rounded-full w-8 h-8;
 }

--- a/src/components/Actions/types.ts
+++ b/src/components/Actions/types.ts
@@ -16,7 +16,7 @@ export interface ActionPropsType<
 > extends ActionType<TRow> {
   children?: ReactNode;
   showText?: boolean;
-  showTooltips?: boolean;
+  "aria-describedby"?: string;
   className?: string;
   stopPropagation?: boolean;
 }

--- a/src/components/Actions/types.ts
+++ b/src/components/Actions/types.ts
@@ -17,6 +17,5 @@ export interface ActionPropsType<
   children?: ReactNode;
   showText?: boolean;
   "aria-describedby"?: string;
-  className?: string;
   stopPropagation?: boolean;
 }

--- a/src/components/Table/components/Rows.tsx
+++ b/src/components/Table/components/Rows.tsx
@@ -96,7 +96,10 @@ export const Rows = <TRow extends BaseDto>(props: RowsPropsType<TRow>) => {
                           <Action
                             {...action}
                             onClick={() => action.onClick(row)}
-                            className="row-table-action"
+                            className={classNames(
+                              "row-table-action",
+                              action.className ?? "",
+                            )}
                           />
                         </Tooltip>
                       ))}

--- a/src/components/Table/components/TableSelectionBar.test.tsx
+++ b/src/components/Table/components/TableSelectionBar.test.tsx
@@ -176,4 +176,25 @@ describe("TableSelectionBar", () => {
 
     expect(screen.getByRole("button").hasAttribute("disabled")).toBe(false);
   });
+
+  it("supports per-action button and icon classes", () => {
+    const action = makeAction({
+      className: "custom-multi-action",
+      iconClassName: "custom-multi-icon",
+    });
+
+    render(
+      <Wrapper>
+        <TableSelectionBar
+          count={1}
+          multiActions={[action]}
+          onActionClick={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const button = screen.getByRole("button", { name: "Delete" });
+    expect(button.classList.contains("custom-multi-action")).toBe(true);
+    expect(button.querySelector(".custom-multi-icon")).toBeTruthy();
+  });
 });

--- a/src/components/Table/components/TableSelectionBar.tsx
+++ b/src/components/Table/components/TableSelectionBar.tsx
@@ -1,7 +1,7 @@
 // components
 import { IconButton, Tooltip } from "components";
 // lib
-import { BaseDto } from "lib";
+import { BaseDto, classNames } from "lib";
 // providers
 import { useTranslation } from "providers";
 
@@ -41,7 +41,8 @@ export function TableSelectionBar<TRow extends BaseDto>({
             <Tooltip key={action.id} content={action.tooltip}>
               <IconButton
                 icon={action.icon}
-                className="multi-table-action"
+                className={classNames("multi-table-action", action.className)}
+                iconClassName={action.iconClassName}
                 onClick={() => onActionClick(action)}
                 disabled={action.disabled}
                 aria-label={action.tooltip}

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -10,6 +10,9 @@ export type ActionType<TRow extends BaseDto> = {
   onClick: (entity?: TRow) => void;
   icon: ReactNode;
   tooltip: string;
+  className?: string;
+  iconClassName?: string;
+  labelClassName?: string;
   disabled?: boolean;
   hidden?: boolean;
   multiple?: boolean;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,3 @@
-// react
 // styles
 import "./styles.css";
 
@@ -7,12 +6,18 @@ import {
   cloneElement,
   isValidElement,
   useCallback,
+  useEffect,
   useId,
+  useLayoutEffect,
   useRef,
+  useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 // types
 import { TooltipPropsType } from "./types";
+
+const GAP = 8;
 
 /**
  * Renders the Tooltip component.
@@ -23,45 +28,94 @@ export function Tooltip(props: TooltipPropsType) {
   const { content, children, className = "" } = props;
 
   const tooltipId = useId();
+  const triggerRef = useRef<HTMLSpanElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
-  const handleMouseEnter = useCallback(() => {
+  const [visible, setVisible] = useState(false);
+  const [coords, setCoords] = useState({ top: 0, left: 0 });
+
+  const show = useCallback(() => setVisible(true), []);
+  const hide = useCallback(() => setVisible(false), []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Escape") hide();
+    },
+    [hide],
+  );
+
+  // Measure trigger + tooltip once visible, then center / clamp / flip.
+  useLayoutEffect(() => {
+    if (!visible) return;
+    const trigger = triggerRef.current;
     const tooltip = tooltipRef.current;
-    if (!tooltip) return;
+    if (!trigger || !tooltip) return;
 
-    // Reset to CSS default so we can measure the natural position
-    tooltip.style.transform = "";
+    const t = trigger.getBoundingClientRect();
+    const tip = tooltip.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
 
-    const rect = tooltip.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
+    // Center horizontally over the trigger, clamp to viewport.
+    let left = t.left + t.width / 2 - tip.width / 2;
+    left = Math.max(GAP, Math.min(left, vw - tip.width - GAP));
 
-    if (rect.left < 0) {
-      tooltip.style.transform = `translateX(calc(-50% + ${Math.ceil(-rect.left)}px))`;
-    } else if (rect.right > viewportWidth) {
-      tooltip.style.transform = `translateX(calc(-50% - ${Math.ceil(rect.right - viewportWidth)}px))`;
-    }
-  }, []);
+    // Prefer above; flip below when there is no room.
+    let top = t.top - tip.height - GAP;
+    if (top < GAP) top = Math.min(t.bottom + GAP, vh - tip.height - GAP);
 
-  const trigger = isValidElement(children)
-    ? cloneElement(children as React.ReactElement, {
-        "aria-describedby": tooltipId,
-      })
-    : children;
+    setCoords({ top, left });
+  }, [visible, content]);
+
+  // Fixed coords don't track scroll/resize, so close the tooltip instead of
+  // letting it drift away from its trigger.
+  useEffect(() => {
+    if (!visible) return;
+    window.addEventListener("scroll", hide, true);
+    window.addEventListener("resize", hide);
+    return () => {
+      window.removeEventListener("scroll", hide, true);
+      window.removeEventListener("resize", hide);
+    };
+  }, [visible, hide]);
+
+  const trigger = isValidElement(children) ? (
+    // Wrapper is the measurement box + event surface. focus/blur bubble up
+    // from the (interactive) child, so we add no extra tab stop here.
+    <span
+      ref={triggerRef}
+      className="tooltip-trigger"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      onKeyDown={handleKeyDown}
+    >
+      {cloneElement(children as React.ReactElement, {
+        // describedby goes on the focused child so screen readers announce it.
+        "aria-describedby": visible ? tooltipId : undefined,
+      })}
+    </span>
+  ) : (
+    children
+  );
 
   return (
-    <div
-      className={classNames("tooltip-container", className)}
-      onMouseEnter={handleMouseEnter}
-    >
+    <>
       {trigger}
-      <div
-        id={tooltipId}
-        role="tooltip"
-        className="tooltip-text"
-        ref={tooltipRef}
-      >
-        {content}
-      </div>
-    </div>
+      {visible &&
+        createPortal(
+          <div
+            id={tooltipId}
+            role="tooltip"
+            ref={tooltipRef}
+            className={classNames("tooltip-text", className)}
+            style={{ top: coords.top, left: coords.left }}
+          >
+            {content}
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }

--- a/src/components/Tooltip/styles.css
+++ b/src/components/Tooltip/styles.css
@@ -1,28 +1,36 @@
-.tooltip-container {
-  position: relative;
+.tooltip-trigger {
   display: inline-block;
   cursor: pointer;
 }
 
 .tooltip-text {
-  visibility: hidden;
-  background-color: black;
-  color: #fff;
+  position: fixed;
+  z-index: 9999;
+  max-width: 280px;
+  width: max-content;
+
+  background-color: var(--tooltip-bg, #1a1a1a);
+  color: var(--tooltip-color, #fff);
   text-align: center;
   padding: 5px 10px;
   border-radius: 5px;
+  font-size: 0.8125rem;
+  pointer-events: none;
 
-  position: absolute;
-  z-index: 9999;
-  bottom: 125%;
-  left: 50%;
-  transform: translateX(-50%);
-
-  opacity: 0;
-  transition: opacity 0.3s;
+  animation: tooltip-fade 0.15s ease-in;
 }
 
-.tooltip-container:hover .tooltip-text {
-  visibility: visible;
-  opacity: 1;
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-text {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## [0.0.85] - 2026-06-14

### Added

- Added `className`, `iconClassName`, and `labelClassName` to `ActionType` so consumers can style action buttons, icon wrappers, and visible labels more precisely.
- Added support for passing action-level button/icon classes through table row sticky actions and selection-bar multi actions.
- Added Storybook and test coverage for `Actions.showTooltips={false}` and for the new action-part class hooks.

### Changed

- Updated `Actions` so icon-only actions use the library `Tooltip` component by default instead of relying on tooltip-specific data attributes on `Action`.
- Updated consumer docs (`docs/usage-guide.md`, `docs/style-customization.md`, and `docs/translations-reference.md`) to document tooltip behavior and the new action styling hooks.

### Fixed

- Fixed tooltip rendering and positioning by moving `Tooltip` to a portal-based implementation that supports hover and focus triggers, closes on `Escape`, clamps horizontally to the viewport, and flips below the trigger when there is no room above.
- Fixed standalone and grouped action tooltip support so `Actions` shows accessible tooltips for icon-only actions by default, while still allowing an opt-out via `showTooltips={false}`.