### PR TITLE
0.1.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.0] - 2026-07-17
+## [0.1.2] - 2026-07-16
+
+### Fixed
+
+- Fixed `AutocompleteInput` in multiple mode so selecting an option with the mouse or keyboard keeps the suggestions open, allowing consecutive selections without refocusing the input.
+- Fixed long selected values overlapping the input label or wrapping onto multiple lines by constraining the chip container, truncating oversized labels, and keeping additional chips on a single line.
+- Fixed the selected-value overflow measurement so the compact first-chip plus `+N` summary is recalculated from the complete selection whenever the value changes.
+- Added regression coverage for selecting multiple suggestions consecutively.
+
+## [0.1.1] - 2026-07-15
+
+## [0.1.0] - 2026-07-15
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "engines": {

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
@@ -72,6 +72,39 @@ describe("AutocompleteInput", () => {
     expect(input).not.toHaveAttribute("required");
   });
 
+  it("allows selecting consecutive suggestions in multiple mode", () => {
+    const Example = () => {
+      const [value, setValue] = useState<Option[] | null>(null);
+      return (
+        <>
+          <AutocompleteInput
+            id="autocomplete-multiple"
+            label="Autocomplete multiple"
+            multiple
+            value={value}
+            onChange={(nextValue) =>
+              setValue(Array.isArray(nextValue) ? nextValue : null)
+            }
+            options={options}
+          />
+          <p data-testid="value">
+            {value?.map((option) => option.name).join(", ") ?? ""}
+          </p>
+        </>
+      );
+    };
+
+    render(<Example />);
+
+    const input = screen.getByLabelText("Autocomplete multiple");
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByText("Apple"));
+    fireEvent.click(screen.getByText("Banana"));
+
+    expect(screen.getByTestId("value")).toHaveTextContent("Apple, Banana");
+    expect(screen.getByText("Cherry")).toBeInTheDocument();
+  });
+
   it("selects the matching option on blur by default", () => {
     const Example = () => {
       const [value, setValue] = useState<Option | Option[] | null>(null);

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
@@ -114,6 +114,8 @@ export const AutocompleteInput = forwardRef(function (
 
   const [threeDots, setThreeDots] = useState(false);
   const multipleValueRef = useRef<HTMLUListElement | null>(null);
+  const measuredValueRef = useRef(value);
+  const hasMeasuredValueRef = useRef(false);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -143,7 +145,7 @@ export const AutocompleteInput = forwardRef(function (
   }, []);
 
   const handleSuggestionClick = useCallback(
-    (suggestion?: Option) => {
+    (suggestion?: Option, keepSuggestionsOpen = false) => {
       if (!suggestion) onChange(null);
       else {
         if (multiple) {
@@ -156,7 +158,7 @@ export const AutocompleteInput = forwardRef(function (
           onChange(suggestion);
         }
       }
-      setShowSuggestions(false);
+      setShowSuggestions(multiple && keepSuggestionsOpen);
     },
     [multiple, onChange, value],
   );
@@ -247,7 +249,7 @@ export const AutocompleteInput = forwardRef(function (
         event.preventDefault();
         const index =
           highlightedSuggestionIndex >= 0 ? highlightedSuggestionIndex : 0;
-        handleSuggestionClick(suggestions[index]);
+        handleSuggestionClick(suggestions[index], true);
         return;
       }
 
@@ -283,10 +285,22 @@ export const AutocompleteInput = forwardRef(function (
   }, [onChange, value]);
 
   useLayoutEffect(() => {
-    const valueWidth = multipleValueRef.current?.offsetWidth ?? 0;
+    if (hasMeasuredValueRef.current && measuredValueRef.current === value) {
+      return;
+    }
+
+    if (threeDots) {
+      setThreeDots(false);
+      return;
+    }
+
+    const valueWidth = multipleValueRef.current?.scrollWidth ?? 0;
     const parentWidth = autocompleteRef.current?.offsetWidth ?? 0;
+
+    measuredValueRef.current = value;
+    hasMeasuredValueRef.current = true;
     setThreeDots(valueWidth > parentWidth * 0.4);
-  }, [value]);
+  }, [threeDots, value]);
 
   return (
     <div
@@ -390,7 +404,7 @@ export const AutocompleteInput = forwardRef(function (
               }
               onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {
-                handleSuggestionClick(suggestion);
+                handleSuggestionClick(suggestion, true);
                 e.stopPropagation();
               }}
               key={suggestion.id ?? suggestion.value ?? suggestion.name}

--- a/src/components/Form/AutocompleteInput/styles.css
+++ b/src/components/Form/AutocompleteInput/styles.css
@@ -31,5 +31,24 @@
 .autocomplete-value-container {
   top: 50%;
   transform: translateY(-50%);
-  @apply flex items-center justify-start flex-wrap gap-2 absolute right-2;
+  max-width: 40%;
+  @apply flex items-center justify-start flex-nowrap gap-2 absolute right-2;
+}
+
+.autocomplete-value-container > li:first-child,
+.autocomplete-value-container .chip-main,
+.autocomplete-value-container .chip-main-text {
+  @apply min-w-0;
+}
+
+.autocomplete-value-container > li:not(:first-child) {
+  @apply shrink-0;
+}
+
+.autocomplete-value-container .chip-main {
+  @apply max-w-full;
+}
+
+.autocomplete-value-container .chip-main-text {
+  @apply truncate;
 }


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.1.2] - 2026-07-16

### Fixed

- Fixed `AutocompleteInput` in multiple mode so selecting an option with the mouse or keyboard keeps the suggestions open, allowing consecutive selections without refocusing the input.
- Fixed long selected values overlapping the input label or wrapping onto multiple lines by constraining the chip container, truncating oversized labels, and keeping additional chips on a single line.
- Fixed the selected-value overflow measurement so the compact first-chip plus `+N` summary is recalculated from the complete selection whenever the value changes.
- Added regression coverage for selecting multiple suggestions consecutively.