### PR TITLE
0.1.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ needed to wire them together.
 npm install @sito/dashboard
 ```
 
-**Peer dependency:** `react` and `react-dom` ≥ 18.2.
+**Peer dependencies:** `@sito/ui` ≥ 0.3.2 and < 0.4.0, plus `react` and `react-dom` ≥ 18.2.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pnpm add @sito/dashboard
 
 ### Peer dependency
 
+- `@sito/ui` (`>=0.3.2 <0.4.0`)
 - `react` (`>=18.2 <20`)
 - `react-dom` (`>=18.2 <20`)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [0.1.3] - 2026-07-16
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Moved `@sito/ui` to peer dependencies with the compatible range `>=0.3.2 <0.4.0`, while keeping `0.3.3` as the development version, so consumers provide one shared primitive instance without requiring a Dashboard release for every compatible UI patch.
+
 ## [0.1.2] - 2026-07-16
 
 ### Fixed

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,7 @@ npm install @sito/dashboard
 
 Required peer dependencies:
 
+- `@sito/ui` `>=0.3.2 <0.4.0`
 - `react` `>=18.2 <20`
 - `react-dom` `>=18.2 <20`
 

--- a/package.json
+++ b/package.json
@@ -124,11 +124,9 @@
   "author": "sito8943",
   "license": "MIT",
   "peerDependencies": {
+    "@sito/ui": ">=0.3.2 <0.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
-  },
-  "dependencies": {
-    "@sito/ui": "0.3.2"
   },
   "overrides": {
     "lodash": "4.18.1",
@@ -148,6 +146,7 @@
     "*.{js,jsx,css,json,md}": "prettier --write"
   },
   "devDependencies": {
+    "@sito/ui": "0.3.3",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.2.0",
     "@storybook/addon-a11y": "10.4.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 
 importers:
   .:
-    dependencies:
-      "@sito/ui":
-        specifier: 0.3.2
-        version: 0.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       "@fortawesome/free-solid-svg-icons":
         specifier: ^7.2.0
@@ -21,6 +17,9 @@ importers:
       "@fortawesome/react-fontawesome":
         specifier: ^3.2.0
         version: 3.4.0(@fortawesome/fontawesome-svg-core@7.3.0)(react@19.2.7)
+      "@sito/ui":
+        specifier: 0.3.3
+        version: 0.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@storybook/addon-a11y":
         specifier: 10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))
@@ -2105,10 +2104,10 @@ packages:
         integrity: sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==,
       }
 
-  "@sito/ui@0.3.2":
+  "@sito/ui@0.3.3":
     resolution:
       {
-        integrity: sha512-gsvweal1m9+Pe3viQatuUZAKW0oYjhBIxRakxwvPSl6k0inDQ9o+oNp+O023L04KPP+Ib6I/c3pNMwSk9sfy2w==,
+        integrity: sha512-kItJChJetoXH4eCjkgSyPwv2wrFkoofpN2T+wVXTEtiuR0P6QxkAUR6XZE6DGq22iR4RX6Qh8InoXCq9EVykCw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     peerDependencies:
@@ -5592,7 +5591,7 @@ snapshots:
       - "@types/node"
     optional: true
 
-  "@sito/ui@0.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@sito/ui@0.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.1.3] - 2026-07-16

### Changed

- Moved `@sito/ui` to peer dependencies with the compatible range `>=0.3.2 <0.4.0`, while keeping `0.3.3` as the development version, so consumers provide one shared primitive instance without requiring a Dashboard release for every compatible UI patch.