### PR TITLE
0.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,6 +507,21 @@ import { AutocompleteInput } from "@sito/dashboard";
 
 `autoSelectOnBlur` defaults to `true`. In single-select mode, when the input loses focus and the typed text exactly matches an option label, that option is selected automatically. Matching is case-insensitive and trims surrounding spaces.
 
+Use `createOption` when the consumer must offer creation for a missing value. The consumer supplies both the localized row label and the creation callback; `AutocompleteInput` only detects the missing exact match and emits the trimmed input value.
+
+```tsx
+<AutocompleteInput
+  label="Country"
+  value={country}
+  onChange={setCountry}
+  options={countryOptions}
+  createOption={{
+    onCreate: (inputValue) => openCreateCountryDialog(inputValue),
+    renderLabel: (inputValue) => `Create "${inputValue}"`,
+  }}
+/>
+```
+
 ### 6.4 `CheckInput`
 
 ```tsx

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export function UsersTable() {
 
 - `SelectInput` expects `Option` items with an `id` (plus optional `value`/`name`).
 - `AutocompleteInput` supports `autoSelectOnBlur` (`true` by default). In single-select mode, blur selects the matching option when the typed text exactly matches an option label, ignoring case and surrounding spaces.
+- `AutocompleteInput` accepts an optional `createOption` configuration. It shows the consumer-rendered creation row only when the trimmed input has no exact option match, then passes that value to `createOption.onCreate` when selected with the mouse or keyboard.
 - `CheckInput` is controlled with `checked` (not `value`).
 - `FileInput` `onChange` receives the native input event; read files from `e.currentTarget.files`.
 - `FileInput` supports `unstyled` (and alias `hiddenContainer`) to render only the native file input when you provide a custom upload UI.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0]
+
+### Added
+
+- Added optional `AutocompleteInput.createOption` support so consumers can render and select a localized creation row when the typed value has no exact option match.
+- Added mouse and keyboard regression coverage plus a `Creatable` Storybook scenario for the new autocomplete flow.
+
 ## [0.1.3] - 2026-07-16
 
 ### Changed

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -66,6 +66,23 @@ const options: Option[] = [
 
 `autoSelectOnBlur` defaults to `true`. In single-select mode, blur selects the matching option when the typed text exactly matches an option label, ignoring case and surrounding spaces.
 
+To let consumers create missing options, pass both the action and its localized label through `createOption`:
+
+```tsx
+<AutocompleteInput
+  value={country}
+  onChange={setCountry}
+  options={countries}
+  label="Country"
+  createOption={{
+    onCreate: (inputValue) => openCreateCountryDialog(inputValue),
+    renderLabel: (inputValue) => `Create "${inputValue}"`,
+  }}
+/>
+```
+
+The creation row appears only for a non-empty value without an exact option match. Matching is case-insensitive and ignores surrounding spaces. The consumer remains responsible for persistence and for updating `options` or `value` after creation.
+
 For custom upload UIs (for example profile photo pickers), render only the native input:
 
 ```tsx

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "engines": {

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.stories.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.stories.tsx
@@ -220,6 +220,57 @@ export const AutoSelectOnBlurDisabled: Story = {
   },
 };
 
+export const Creatable: Story = {
+  render: (args) => {
+    const Example = () => {
+      const [availableOptions, setAvailableOptions] =
+        useState<Option[]>(options);
+      const [value, setValue] = useState<Option | Option[] | null>(null);
+
+      const handleCreate = (inputValue: string) => {
+        const createdOption: Option = {
+          id: `created-${inputValue.toLowerCase()}`,
+          name: inputValue,
+        };
+
+        setAvailableOptions((currentOptions) => [
+          ...currentOptions,
+          createdOption,
+        ]);
+        setValue(createdOption);
+      };
+
+      return (
+        <div className="max-w-sm">
+          <AutocompleteInput
+            {...args}
+            label="Fruta"
+            placeholder="Busca o crea una fruta"
+            options={availableOptions}
+            value={value}
+            onChange={setValue}
+            createOption={{
+              onCreate: handleCreate,
+              renderLabel: (inputValue) => `Crear "${inputValue}"`,
+            }}
+          />
+          <p className="mt-2 text-sm text-gray-500">
+            Escribe una fruta que no exista y selecciona la opción de creación.
+          </p>
+          {!Array.isArray(value) && (
+            <p className="mt-2 text-sm text-gray-500">
+              Valor: {value ? String(value.name ?? value.value) : "(vacío)"}
+            </p>
+          )}
+        </div>
+      );
+    };
+
+    return <Example />;
+  },
+  args: { state: State.default },
+};
+
 export const CustomLabel: Story = {
   render: (args) => {
     const Example = () => {

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.test.tsx
@@ -3,7 +3,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Option } from "components";
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { AutocompleteInput } from "./AutocompleteInput";
 
@@ -160,5 +160,100 @@ describe("AutocompleteInput", () => {
     fireEvent.blur(input);
 
     expect(screen.getByTestId("value")).toHaveTextContent("");
+  });
+
+  it("offers creation when the typed value has no exact option match", () => {
+    const onCreate = vi.fn();
+
+    render(
+      <AutocompleteInput
+        id="autocomplete-create"
+        label="Autocomplete create"
+        value={null}
+        onChange={() => undefined}
+        options={options}
+        createOption={{
+          onCreate,
+          renderLabel: (inputValue) => `Create "${inputValue}"`,
+        }}
+      />,
+    );
+
+    const input = screen.getByLabelText("Autocomplete create");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "  Dragon fruit  " } });
+
+    fireEvent.click(screen.getByText('Create "Dragon fruit"'));
+
+    expect(onCreate).toHaveBeenCalledOnce();
+    expect(onCreate).toHaveBeenCalledWith("Dragon fruit");
+  });
+
+  it("does not offer creation when an exact option already exists", () => {
+    render(
+      <AutocompleteInput
+        id="autocomplete-create-existing"
+        label="Autocomplete create existing"
+        value={null}
+        onChange={() => undefined}
+        options={options}
+        createOption={{
+          onCreate: () => undefined,
+          renderLabel: (inputValue) => `Create "${inputValue}"`,
+        }}
+      />,
+    );
+
+    const input = screen.getByLabelText("Autocomplete create existing");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: " apple " } });
+
+    expect(screen.queryByText('Create "apple"')).not.toBeInTheDocument();
+  });
+
+  it("creates the typed option with Enter when no suggestion matches", () => {
+    const onCreate = vi.fn();
+
+    render(
+      <AutocompleteInput
+        id="autocomplete-create-keyboard"
+        label="Autocomplete create keyboard"
+        value={null}
+        onChange={() => undefined}
+        options={options}
+        createOption={{
+          onCreate,
+          renderLabel: (inputValue) => `Create "${inputValue}"`,
+        }}
+      />,
+    );
+
+    const input = screen.getByLabelText("Autocomplete create keyboard");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Dragon fruit" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCreate).toHaveBeenCalledWith("Dragon fruit");
+  });
+
+  it("does not offer creation for a selected value missing from options", () => {
+    render(
+      <AutocompleteInput
+        id="autocomplete-create-selected"
+        label="Autocomplete create selected"
+        value={{ id: 4, name: "Dragon fruit" }}
+        onChange={() => undefined}
+        options={options}
+        createOption={{
+          onCreate: () => undefined,
+          renderLabel: (inputValue) => `Create "${inputValue}"`,
+        }}
+      />,
+    );
+
+    const input = screen.getByLabelText("Autocomplete create selected");
+    fireEvent.focus(input);
+
+    expect(screen.queryByText('Create "Dragon fruit"')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/Form/AutocompleteInput/AutocompleteInput.tsx
@@ -45,6 +45,7 @@ export const AutocompleteInput = forwardRef(function (
     placeholder = "",
     multiple = false,
     autoSelectOnBlur = true,
+    createOption,
     required = false,
     "aria-required": ariaRequired = false,
     onBlur,
@@ -101,13 +102,29 @@ export const AutocompleteInput = forwardRef(function (
     [availableOptions, getOptionLabel, inputValue],
   );
 
+  const trimmedInputValue = inputValue.trim();
+  const canCreateOption = useMemo(() => {
+    if (!createOption || !trimmedInputValue) return false;
+
+    const normalizedInputValue = trimmedInputValue.toLowerCase();
+    const selectedOptions = Array.isArray(value) ? value : value ? [value] : [];
+    const knownOptions = [...options, ...selectedOptions];
+
+    return !knownOptions.some(
+      (option) =>
+        getOptionLabel(option).trim().toLowerCase() === normalizedInputValue,
+    );
+  }, [createOption, getOptionLabel, options, trimmedInputValue, value]);
+
+  const suggestionCount = suggestions.length + (canCreateOption ? 1 : 0);
+
   useEffect(() => {
-    if (!showSuggestions || !suggestions.length) {
+    if (!showSuggestions || !suggestionCount) {
       setHighlightedSuggestionIndex(-1);
       return;
     }
     setHighlightedSuggestionIndex(0);
-  }, [showSuggestions, suggestions]);
+  }, [showSuggestions, suggestionCount, suggestions]);
 
   const autocompleteRef = useRef<HTMLDivElement | null>(null);
   const localInputRef = useRef<HTMLInputElement | null>(null);
@@ -162,6 +179,13 @@ export const AutocompleteInput = forwardRef(function (
     },
     [multiple, onChange, value],
   );
+
+  const handleCreateOption = useCallback(() => {
+    if (!createOption || !canCreateOption) return;
+
+    createOption.onCreate(trimmedInputValue);
+    setShowSuggestions(false);
+  }, [canCreateOption, createOption, trimmedInputValue]);
 
   const findSuggestionMatchingInput = useCallback(
     (searchValue: string) => {
@@ -221,7 +245,7 @@ export const AutocompleteInput = forwardRef(function (
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {
-      if (!suggestions.length) {
+      if (!suggestionCount) {
         if (event.key === "Escape") {
           setShowSuggestions(false);
         }
@@ -238,9 +262,9 @@ export const AutocompleteInput = forwardRef(function (
         setHighlightedSuggestionIndex((currentIndex) => {
           const baseIndex = currentIndex >= 0 ? currentIndex : 0;
           if (event.key === "ArrowDown") {
-            return (baseIndex + 1 + suggestions.length) % suggestions.length;
+            return (baseIndex + 1 + suggestionCount) % suggestionCount;
           }
-          return (baseIndex - 1 + suggestions.length) % suggestions.length;
+          return (baseIndex - 1 + suggestionCount) % suggestionCount;
         });
         return;
       }
@@ -249,6 +273,10 @@ export const AutocompleteInput = forwardRef(function (
         event.preventDefault();
         const index =
           highlightedSuggestionIndex >= 0 ? highlightedSuggestionIndex : 0;
+        if (canCreateOption && index === suggestions.length) {
+          handleCreateOption();
+          return;
+        }
         handleSuggestionClick(suggestions[index], true);
         return;
       }
@@ -260,8 +288,11 @@ export const AutocompleteInput = forwardRef(function (
     },
     [
       handleSuggestionClick,
+      handleCreateOption,
+      canCreateOption,
       highlightedSuggestionIndex,
       showSuggestions,
+      suggestionCount,
       suggestions,
     ],
   );
@@ -412,6 +443,27 @@ export const AutocompleteInput = forwardRef(function (
               {suggestion.value ?? suggestion.name}
             </li>
           ))}
+          {canCreateOption && createOption ? (
+            <li
+              className={classNames(
+                "autocomplete-suggestion-item",
+                "autocomplete-create-option",
+                highlightedSuggestionIndex === suggestions.length
+                  ? "highlighted"
+                  : "",
+              )}
+              onMouseEnter={() =>
+                setHighlightedSuggestionIndex(suggestions.length)
+              }
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={(event) => {
+                handleCreateOption();
+                event.stopPropagation();
+              }}
+            >
+              {createOption.renderLabel(trimmedInputValue)}
+            </li>
+          ) : null}
         </ul>
       )}
     </div>

--- a/src/components/Form/AutocompleteInput/styles.css
+++ b/src/components/Form/AutocompleteInput/styles.css
@@ -28,6 +28,10 @@
   @apply p-2 cursor-pointer;
 }
 
+.autocomplete-create-option {
+  @apply font-semibold text-bg-primary;
+}
+
 .autocomplete-value-container {
   top: 50%;
   transform: translateY(-50%);

--- a/src/components/Form/AutocompleteInput/types.ts
+++ b/src/components/Form/AutocompleteInput/types.ts
@@ -1,5 +1,11 @@
 // types
 import { Option, TextInputPropsType } from "components";
+import { ReactNode } from "react";
+
+export interface AutocompleteCreateOptionConfig {
+  onCreate: (inputValue: string) => void;
+  renderLabel: (inputValue: string) => ReactNode;
+}
 
 export interface AutocompleteInputPropsType extends Omit<
   TextInputPropsType,
@@ -9,6 +15,7 @@ export interface AutocompleteInputPropsType extends Omit<
   onChange: (value: Option | Option[] | null) => void;
   multiple?: boolean;
   autoSelectOnBlur?: boolean;
+  createOption?: AutocompleteCreateOptionConfig;
   inputContainerClassName?: string;
   options: Option[];
 }


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.2.0]

### Added

- Added optional `AutocompleteInput.createOption` support so consumers can render and select a localized creation row when the typed value has no exact option match.
- Added mouse and keyboard regression coverage plus a `Creatable` Storybook scenario for the new autocomplete flow.
