### PR TITLE
0.3.0

### DIFF
--- a/.storybook/theme.css
+++ b/.storybook/theme.css
@@ -113,10 +113,7 @@
 .table-navigation-buttons:disabled {
   color: var(--color-text-muted);
 }
-.table-headers-cell {
-  border-color: var(--color-border);
-}
-.table-headers-cell:hover {
+.table-headers-sort-preview-trigger:hover {
   background-color: var(--color-base-dark);
 }
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ import { SortOrder, TableOptionsProvider } from "@sito/dashboard";
 | `canHideColumns`            | `boolean`                                                         | No       | Shows column visibility menu in the header.                                 |
 | `canReset`                  | `boolean`                                                         | No       | Shows table reset button in the header.                                     |
 | `onSort`                    | `(prop: string, sortOrder: SortOrder) => void`                    | No       | Sort callback when a sortable column is toggled.                            |
+| `showSortPreviewOnHover`    | `boolean`                                                         | No       | Previews the next order while hovering an inactive sortable header.         |
 | `onRowSelect`               | `(row: TRow, selected: boolean) => void`                          | No       | Row selection callback.                                                     |
 | `onSelectedRowsChange`      | `(rows: TRow[]) => void`                                          | No       | Callback with selected rows.                                                |
 | `softDeleteProperty`        | `keyof TRow`                                                      | No       | Property name used to determine soft-deleted rows. Defaults to `deletedAt`. |

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0]
+
+### Added
+
+- Added the optional `Table.showSortPreviewOnHover` prop, disabled by default, so inactive sortable headers can preview the order that the next click will apply.
+- Added a reserved sort-indicator state to prevent header content from shifting when the current or preview chevron becomes visible.
+- Added regression coverage, a Storybook scenario, and consumer documentation for sortable-header hover previews.
+
+### Changed
+
+- Reused a shared next-sort-order helper for both hover previews and sort interactions, keeping the displayed preview aligned with the order applied on click.
+
+### Fixed
+
+- Limited sortable-header hover background styles to inactive headers with previews enabled, preventing normal and active header hover styles from being overridden.
+
 ## [0.2.0]
 
 ### Added

--- a/docs/table-guide.md
+++ b/docs/table-guide.md
@@ -12,6 +12,7 @@
 | `toolbar`                   | `ReactNode`                                | Right area in header.                                |
 | `isLoading`                 | `boolean`                                  | Loading state.                                       |
 | `onSort`                    | `(prop, order) => void`                    | Sort callback.                                       |
+| `showSortPreviewOnHover`    | `boolean`                                  | Preview the next order on inactive-header hover.     |
 | `onRowSelect`               | `(row, selected) => void`                  | Single-row selection callback.                       |
 | `onSelectedRowsChange`      | `(rows) => void`                           | All selected rows callback.                          |
 | `onRowExpand`               | `(expandedRow, collapsedRow) => ReactNode` | Expanded row content.                                |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sito/dashboard",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "engines": {

--- a/src/components/Table/Table.sortPreview.test.tsx
+++ b/src/components/Table/Table.sortPreview.test.tsx
@@ -1,0 +1,84 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { BaseDto, SortOrder } from "lib";
+import { TableOptionsProvider, TranslationProvider } from "providers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ColumnType } from "./components";
+import { Table } from "./Table";
+
+type Row = BaseDto & {
+  name: string;
+  age: number;
+};
+
+const rows: Row[] = [{ id: 1, name: "Alice", age: 28 }];
+const columns: ColumnType<Row>[] = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "age", label: "Age", sortable: true },
+];
+
+const getHeaderButton = (label: string) => {
+  const button = screen.getByText(label).closest("button");
+  if (!button) throw new Error(`Missing header button: ${label}`);
+  return button;
+};
+
+const getSortState = (button: HTMLButtonElement) => {
+  const state = button.querySelector<HTMLElement>("[data-sort-order]");
+  if (!state) throw new Error("Missing reserved sort indicator");
+  return state;
+};
+
+const renderTable = (showSortPreviewOnHover?: boolean) =>
+  render(
+    <TranslationProvider t={(key) => key} language="en">
+      <TableOptionsProvider
+        initialState={{
+          sortingBy: "name",
+          sortingOrder: SortOrder.DESC,
+        }}
+      >
+        <Table<Row>
+          entity="users"
+          data={rows}
+          columns={columns}
+          showSortPreviewOnHover={showSortPreviewOnHover}
+        />
+      </TableOptionsProvider>
+    </TranslationProvider>,
+  );
+
+describe("Table sortable header preview", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reserves the indicator and enables preview only for inactive columns", () => {
+    renderTable(true);
+
+    const nameHeader = getHeaderButton("Name");
+    const ageHeader = getHeaderButton("Age");
+    const nameSortState = getSortState(nameHeader);
+    const ageSortState = getSortState(ageHeader);
+
+    expect(nameSortState).toHaveAttribute("data-sort-order", SortOrder.DESC);
+    expect(nameSortState).toHaveClass("table-headers-sort-current");
+    expect(nameHeader).not.toHaveClass("table-headers-sort-preview-trigger");
+    expect(ageSortState).toHaveAttribute("data-sort-order", SortOrder.DESC);
+    expect(ageSortState).toHaveClass("table-headers-sort-preview");
+    expect(ageHeader).toHaveClass("table-headers-sort-preview-trigger");
+  });
+
+  it("keeps hover previews disabled by default", () => {
+    renderTable();
+
+    const ageHeader = getHeaderButton("Age");
+    const ageSortState = getSortState(ageHeader);
+
+    expect(ageSortState).toHaveAttribute("data-sort-order", SortOrder.DESC);
+    expect(ageSortState).toHaveClass("table-headers-sort-placeholder");
+    expect(ageHeader).not.toHaveClass("table-headers-sort-preview-trigger");
+  });
+});

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -111,6 +111,14 @@ export const Basic: Story = {
   } as any,
 };
 
+export const WithSortPreviewOnHover: Story = {
+  args: {
+    ...Basic.args,
+    title: "Usuarios — sort preview on hover",
+    showSortPreviewOnHover: true,
+  },
+};
+
 export const WithAutocompleteFilter: Story = {
   args: {
     entity: "users",

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -44,6 +44,7 @@ export function Table<TRow extends BaseDto>(props: TablePropsType<TRow>) {
     columns = [],
     contentClassName = "",
     className = "",
+    showSortPreviewOnHover = false,
     softDeleteProperty = "deletedAt",
     onRowSelect,
     onSelectedRowsChange,
@@ -107,6 +108,7 @@ export function Table<TRow extends BaseDto>(props: TablePropsType<TRow>) {
                       entity={entity}
                       columns={columns}
                       onSortCallback={onSort}
+                      showSortPreviewOnHover={showSortPreviewOnHover}
                       hasAction={!!actions}
                       selectionState={selectionState}
                       onToggleAllRows={onToggleAllRows}

--- a/src/components/Table/components/Columns.tsx
+++ b/src/components/Table/components/Columns.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronUp } from "components/SvgIcons";
 import { BaseDto, classNames, SortOrder } from "lib";
 // providers
 import { useTableOptions, useTranslation } from "providers";
+import { getNextSortingOrder } from "providers/TableOptions/utils";
 import { useEffect, useMemo, useRef } from "react";
 
 // utils
@@ -24,6 +25,7 @@ export function Columns<TRow extends BaseDto>(props: ColumnPropsType<TRow>) {
     entity = "",
     columns = [],
     hasAction = true,
+    showSortPreviewOnHover = false,
     onSortCallback,
     selectionState,
     onToggleAllRows,
@@ -73,46 +75,71 @@ export function Columns<TRow extends BaseDto>(props: ColumnPropsType<TRow>) {
             <span>{t("_accessibility:labels.actions")}</span>
           </th>
         )}
-        {parsedColumns.map((column) => (
-          <th
-            key={column.id}
-            scope="col"
-            className={classNames("table-headers-column", column.className)}
-          >
-            <Button
-              disabled={!column.sortable}
-              onClick={() => onSort(column.id, onSortCallback)}
-              className="table-headers-cell"
+        {parsedColumns.map((column) => {
+          const isActiveSort = sortingBy === column.id;
+          const displayedSortOrder = isActiveSort
+            ? sortingOrder
+            : getNextSortingOrder(sortingBy, sortingOrder, column.id);
+          const canShowSortPreview = showSortPreviewOnHover && !isActiveSort;
+          let sortStateClassName = "table-headers-sort-placeholder";
+          if (isActiveSort) {
+            sortStateClassName = "table-headers-sort-current";
+          } else if (canShowSortPreview) {
+            sortStateClassName = "table-headers-sort-preview";
+          }
+
+          return (
+            <th
+              key={column.id}
+              scope="col"
+              className={classNames("table-headers-column", column.className)}
             >
-              {column.renderHead ? (
-                column.renderHead()
-              ) : (
-                <span className="table-headers-label">{column.label}</span>
-              )}
-              {column.sortable && sortingBy === column.id && (
-                <span>
-                  {sortingOrder === SortOrder.ASC
-                    ? (column.sortOptions?.icons?.asc ?? (
-                        <ChevronUp
-                          className={
-                            column.sortOptions?.icons?.className ??
-                            "table-headers-sort-indicator"
-                          }
-                        />
-                      ))
-                    : (column.sortOptions?.icons?.desc ?? (
-                        <ChevronDown
-                          className={
-                            column.sortOptions?.icons?.className ??
-                            "table-headers-sort-indicator"
-                          }
-                        />
-                      ))}
-                </span>
-              )}
-            </Button>
-          </th>
-        ))}
+              <Button
+                disabled={!column.sortable}
+                onClick={() => onSort(column.id, onSortCallback)}
+                className={classNames(
+                  "table-headers-cell",
+                  column.sortable &&
+                    canShowSortPreview &&
+                    "table-headers-sort-preview-trigger",
+                )}
+              >
+                {column.renderHead ? (
+                  column.renderHead()
+                ) : (
+                  <span className="table-headers-label">{column.label}</span>
+                )}
+                {column.sortable && (
+                  <span
+                    className={classNames(
+                      "table-headers-sort-state",
+                      sortStateClassName,
+                    )}
+                    data-sort-order={displayedSortOrder}
+                  >
+                    {displayedSortOrder === SortOrder.ASC
+                      ? (column.sortOptions?.icons?.asc ?? (
+                          <ChevronUp
+                            className={
+                              column.sortOptions?.icons?.className ??
+                              "table-headers-sort-indicator"
+                            }
+                          />
+                        ))
+                      : (column.sortOptions?.icons?.desc ?? (
+                          <ChevronDown
+                            className={
+                              column.sortOptions?.icons?.className ??
+                              "table-headers-sort-indicator"
+                            }
+                          />
+                        ))}
+                  </span>
+                )}
+              </Button>
+            </th>
+          );
+        })}
       </tr>
     </thead>
   );

--- a/src/components/Table/components/styles.css
+++ b/src/components/Table/components/styles.css
@@ -31,6 +31,23 @@
   @apply whitespace-nowrap;
 }
 
+.table-headers-cell {
+  @apply transition-colors duration-200;
+}
+
+.table-headers-sort-state {
+  @apply inline-flex opacity-0 transition-opacity duration-200;
+}
+
+.table-headers-sort-current,
+.table-headers-sort-preview-trigger:hover .table-headers-sort-preview {
+  @apply opacity-100;
+}
+
+.table-headers-sort-preview-trigger:hover {
+  @apply bg-base-dark;
+}
+
 .table-headers-sort-indicator {
   @apply w-3;
 }

--- a/src/components/Table/components/types.ts
+++ b/src/components/Table/components/types.ts
@@ -38,6 +38,7 @@ export type ColumnPropsType<TRow extends BaseDto> = {
   entity: string;
   columns: ColumnType<TRow>[];
   hasAction: boolean;
+  showSortPreviewOnHover?: boolean;
   onSortCallback?: (
     prop: Extract<keyof TRow, string>,
     sortOrder: SortOrder,

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -28,6 +28,8 @@ export interface TablePropsType<
   actions?: (row: TRow) => ActionType<TRow>[];
   contentClassName?: string;
   className?: string;
+  /** Previews the next order while hovering an inactive sortable header. */
+  showSortPreviewOnHover?: boolean;
   softDeleteProperty?: keyof TRow;
   onSort?: (prop: Extract<keyof TRow, string>, sortOrder: SortOrder) => void;
   onRowSelect?: (row: TRow, selected: boolean) => void;

--- a/src/providers/TableOptions/TableOptionsProvider.tsx
+++ b/src/providers/TableOptions/TableOptionsProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "./types";
 // utils
 import {
+  getNextSortingOrder,
   hasMeaningfulFilterValue,
   parseFilters,
   parseNonNegativeInteger,
@@ -135,16 +136,11 @@ const TableOptionsProvider = <
       attribute: TColumnKey,
       onSortCallback?: (prop: TColumnKey, sortOrder: SortOrder) => void,
     ) => {
-      let localSortingOrder = sortingOrder;
-      if (sortingBy === attribute)
-        switch (sortingOrder) {
-          case SortOrder.ASC:
-            localSortingOrder = SortOrder.DESC;
-            break;
-          default:
-            localSortingOrder = SortOrder.ASC;
-            break;
-        }
+      const localSortingOrder = getNextSortingOrder(
+        sortingBy,
+        sortingOrder,
+        attribute,
+      );
       setSortingBy(attribute);
       setSortingOrder(localSortingOrder);
 

--- a/src/providers/TableOptions/utils.ts
+++ b/src/providers/TableOptions/utils.ts
@@ -92,6 +92,25 @@ export const parseSortingOrder = (sortingOrder: SortOrder | undefined) => {
 };
 
 /**
+ * Returns the order that will be applied by the next sort interaction.
+ *
+ * Selecting a different column preserves the current order. Selecting the
+ * active column toggles it.
+ * @param sortingBy - Currently active sorting key.
+ * @param sortingOrder - Currently active sorting order.
+ * @param nextSortingBy - Column targeted by the next interaction.
+ * @returns The order that the next sort interaction will apply.
+ */
+export const getNextSortingOrder = <TColumnKey extends string>(
+  sortingBy: TColumnKey,
+  sortingOrder: SortOrder,
+  nextSortingBy: TColumnKey,
+) => {
+  if (sortingBy !== nextSortingBy) return sortingOrder;
+  return sortingOrder === SortOrder.ASC ? SortOrder.DESC : SortOrder.ASC;
+};
+
+/**
  * Clones the filters object when it is valid.
  * @param filters - Optional table filters state.
  * @returns A shallow copy of filters, or an empty object for invalid input.


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [0.3.0]

### Added

- Added the optional `Table.showSortPreviewOnHover` prop, disabled by default, so inactive sortable headers can preview the order that the next click will apply.
- Added a reserved sort-indicator state to prevent header content from shifting when the current or preview chevron becomes visible.
- Added regression coverage, a Storybook scenario, and consumer documentation for sortable-header hover previews.

### Changed

- Reused a shared next-sort-order helper for both hover previews and sort interactions, keeping the displayed preview aligned with the order applied on click.

### Fixed

- Limited sortable-header hover background styles to inactive headers with previews enabled, preventing normal and active header hover styles from being overridden.